### PR TITLE
Require Jinja2 >= 2.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     python_requires='>=3.6',
     install_requires=[
         'sphinx>=3.1.2',
+        'jinja2>=2.11',  # suport for pathlib.Path
     ],
     author='Matthias Geier',
     author_email='Matthias.Geier@gmail.com',


### PR DESCRIPTION
... because we are using `pathlib.Path`.

This has been reported via the `sphinx-users` mailing list: https://groups.google.com/g/sphinx-users/c/KUvIuc1EXRQ/m/li2ibgMlBgAJ