### PR TITLE
Explicit CSS for line numbers in code blocks

### DIFF
--- a/doc/showcase/code-blocks.rst
+++ b/doc/showcase/code-blocks.rst
@@ -85,15 +85,6 @@ No language:
     print('Hello,')
     print('world!')
 
-.. note::
-
-    There are problems with the style of line numbers when using Pygments 2.7+,
-    see https://github.com/sphinx-doc/sphinx/issues/8254.
-    Until this is fixed, you can pin your version of Pygments::
-
-        python3 -m pip install "pygments<2.7"
-
-
 ``:emphasize-lines:``
 
 .. code-block:: python

--- a/src/insipid_sphinx_theme/insipid/static/insipid.css_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid.css_t
@@ -293,6 +293,16 @@ div.code-block-caption {
     font-size: unset;
 }
 
+td.linenos .linenodiv pre {
+    color: #666;
+    background-color: transparent;
+    padding: 7px 0px;
+}
+
+table.highlighttable td.linenos {
+    padding-right: 0.5em;
+}
+
 /* highlighted line (:emphasize-lines:) */
 .highlight .hll {
     padding: 0 0.5em;


### PR DESCRIPTION
This works around https://github.com/pygments/pygments/issues/1579.

Rendered: https://insipid-sphinx-theme--21.org.readthedocs.build/en/21/showcase/code-blocks.html#code-block-directive