### PR TITLE
Make the relbar arrows always dark

### DIFF
--- a/src/insipid_sphinx_theme/insipid/static/insipid.css_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid.css_t
@@ -551,6 +551,10 @@ div.body dl.exception > dt:not(:target) {
     text-align: right;
 }
 
+.relbar .icon {
+    color: #333;
+}
+
 .relbar .previous .icon {
     margin-right: 1em;
 }


### PR DESCRIPTION
... not only when hovering.
The previous/next titles are still very light and get darker when hovering.

Rendered: https://insipid-sphinx-theme--24.org.readthedocs.build/en/24/