### PR TITLE
Remove "viewport" tag

### DIFF
--- a/src/insipid_sphinx_theme/insipid/layout.html
+++ b/src/insipid_sphinx_theme/insipid/layout.html
@@ -66,7 +66,6 @@
 
 
 {% block extrahead %}
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
 {%- endblock %}


### PR DESCRIPTION
This has been added to the basic theme in https://github.com/sphinx-doc/sphinx/pull/7695, which is included since Sphinx 3.1.0.