### PR TITLE
CSS: avoid multiple borders with compound "kbd" role

### DIFF
--- a/doc/showcase/basic-formatting.rst
+++ b/doc/showcase/basic-formatting.rst
@@ -184,7 +184,8 @@ command: :command:`rm` --
 dfn: :dfn:`term` --
 file: :file:`name.{ext}` --
 guilabel: :guilabel:`&Cancel` --
-kbd: :kbd:`Control` + :kbd:`x` :kbd:`Control` + :kbd:`f` --
+kbd (separate): :kbd:`Control` + :kbd:`x` :kbd:`Control` + :kbd:`f` --
+kbd (combined, needs Sphinx >= 3.5.0): :kbd:`Control+x Control+f` --
 mailheader: :mailheader:`Content-Type` --
 makevar: :makevar:`AM_CFLAGS` --
 manpage: :manpage:`ls(1)`, :manpage:`man` --

--- a/src/insipid_sphinx_theme/insipid/static/insipid.css_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid.css_t
@@ -316,7 +316,7 @@ table.highlighttable td.linenos {
     margin: 0 -0.5em;
 }
 
-kbd.docutils {
+kbd.docutils:not(.compound) {
     padding: 0.15em;
     border-radius: 3px;
     border: 1px solid #333;


### PR DESCRIPTION
This needs Sphinx >= 3.5.0, see
https://github.com/sphinx-doc/sphinx/pull/8620.

Rendered: https://insipid-sphinx-theme--35.org.readthedocs.build/en/35/showcase/basic-formatting.html#other-semantic-markup