### PR TITLE
Fix CSS for compound paragraphs

### DIFF
--- a/src/insipid_sphinx_theme/insipid/static/insipid.css_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid.css_t
@@ -201,22 +201,22 @@ img {
     max-width: unset;
 }
 
-.compound {
+div.compound {
     margin-top: 1em;
     margin-bottom: 1em;
 }
 
-.compound-first {
+div.compound > .compound-first {
     margin-top: 0;
-    margin-bottom: 0.5em;
+    margin-bottom: 0.2em;
 }
 
-.compound-middle {
-    margin-top: 0.5em;
-    margin-bottom: 0.5em;
+div.compound > .compound-middle {
+    margin-top: 0.2em;
+    margin-bottom: 0.2em;
 }
-.compound-last {
-    margin-top: 0.5em;
+div.compound > .compound-last {
+    margin-top: 0.2em;
     margin-bottom: 0;
 }
 


### PR DESCRIPTION
This also avoids confusion with the new `compound` class for the `kbd` role: https://github.com/sphinx-doc/sphinx/pull/8620

Rendered: https://insipid-sphinx-theme--36.org.readthedocs.build/en/36/showcase/basic-formatting.html#compound-paragraphs