### PR TITLE
Disallow docutils 0.17+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     install_requires=[
         'sphinx>=3.1.2',
         'jinja2>=2.11',  # suport for pathlib.Path
+        'docutils<0.17',  # https://github.com/sphinx-doc/sphinx/issues/9001
     ],
     author='Matthias Geier',
     author_email='Matthias.Geier@gmail.com',


### PR DESCRIPTION
See https://github.com/sphinx-doc/sphinx/issues/9001.

This limitation should be removed again once Sphinx supports docutils 0.17+ (see #41).