### PR TITLE
Unpin docutils dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     install_requires=[
         'sphinx>=3.1.2',
         'jinja2>=2.11',  # suport for pathlib.Path
-        'docutils<0.17',  # https://github.com/sphinx-doc/sphinx/issues/9001
+        'docutils',
     ],
     author='Matthias Geier',
     author_email='Matthias.Geier@gmail.com',


### PR DESCRIPTION
Reverts #40.

This should be merged/released *after* the release of Sphinx 4.0.0.