### PR TITLE
Check for <section> element

### DIFF
--- a/src/insipid_sphinx_theme/insipid/static/insipid.js
+++ b/src/insipid_sphinx_theme/insipid/static/insipid.js
@@ -49,7 +49,7 @@ $(document).ready(function () {
     }
 
     var div_body = document.querySelector('div.body');
-    var first_section = document.querySelector('div.body .section');
+    var first_section = document.querySelector('div.body .section, div.body section');
     if (first_section) {
         $(document).on('scroll', function () {
             if (window.pageYOffset >= div_body.offsetTop + first_section.offsetTop) {


### PR DESCRIPTION
... in addition to class="section".

Since `docutils` 0.17, `<section>` elements are generated, which were not considered before.

Because of this, the page title wasn't shown in the topbar when scrolling down.