### PR TITLE
Collapse sidebar on small devices if there is only one section

### DIFF
--- a/src/insipid_sphinx_theme/insipid/static/insipid-sidebar.js_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid-sidebar.js_t
@@ -266,6 +266,10 @@ $(document).ready(function () {
             hideSidebar();
         }
     })
+
+    if ($current.length == 1 && $overlay.css('position') === 'fixed') {
+        hideSidebar();
+    }
 });
 
 {#


### PR DESCRIPTION
This should fix #53.

In the `insipid` docs this doesn't work on the main page because there are multiple (identical) links to the main page in the sidebar.

On other single-section pages (like "Installation and Usage" and "Version History") this should work.

Rendered: https://insipid-sphinx-theme--54.org.readthedocs.build/en/54/