### PR TITLE
Refine sidebar hiding

### DIFF
--- a/src/insipid_sphinx_theme/insipid/static/insipid-sidebar.js_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid-sidebar.js_t
@@ -261,13 +261,13 @@ $(document).ready(function () {
         }
     }
 
-    $current.on('click', 'a', function () {
+    $current.on('click', '> a', function () {
         if ($overlay.css('position') === 'fixed') {
             hideSidebar();
         }
     })
 
-    if ($current.length == 1 && $overlay.css('position') === 'fixed') {
+    if ($current.length == 1 && $current[0].childElementCount == 1 && $overlay.css('position') === 'fixed') {
         hideSidebar();
     }
 });


### PR DESCRIPTION
There is an edge case which I have not considered in #54: there can be a page with only one section on the page itself but with sub-pages, and in this case I don't want to hide the sidebar.

An example for this situation: https://nbsphinx.readthedocs.io/en/0.8.6/subdir/gallery.html

@lsaffre Can you please check if that still works for you?