### PR TITLE
Add large table example

### DIFF
--- a/doc/showcase/tables.rst
+++ b/doc/showcase/tables.rst
@@ -126,7 +126,7 @@ Large Table
 -----------
 
 .. csv-table:: A wide table
-    :header: Label,Parameter1,Parameter2,Parameter3,Parameter4,Measure1,Measure2,Measure3,Measure4
+    :header: Label,Parameter1,Parameter2,Parameter3,Parameter4,Measure1,Measure2,Measure3
 
     Some fancy name1,first linear classifier,flying,denoised,emotional,0.9,0.6,3.12
     Some fancy name2,second linear classifier,driving,noisy,emotional,0.8,0.6,4.23

--- a/doc/showcase/tables.rst
+++ b/doc/showcase/tables.rst
@@ -135,7 +135,7 @@ Large Table
     Some fancy name5,fifth linear classifier,dancing,denoised,emotional,0.4,0.6,9.37
     Some fancy name6,sixth linear classifier,sliding,noisy,emotional,0.8,0.6,4.32
     Some fancy name7,seventh linear classifier,walking,denoised,non emotional,0.9,0.6,2.12
-    Some fancy name8,eights linear classifier,diving,noisy,emotional,0.2,0.4,4.32
+    Some fancy name8,eighth linear classifier,diving,noisy,emotional,0.2,0.4,4.32
     Some fancy name9,ninth linear classifier,strolling,denoised,non emotional,0.5,0.6,2.42
 
 

--- a/doc/showcase/tables.rst
+++ b/doc/showcase/tables.rst
@@ -122,6 +122,24 @@ https://docutils.sourceforge.io/docs/ref/rst/directives.html#list-table
      - On a stick!
 
 
+Large Table
+-----------
+
+.. csv-table:: A wide table
+    :header: Label,Parameter1,Parameter2,Parameter3,Parameter4,Measure1,Measure2,Measure3,Measure4
+
+    Some fancy name1,first linear classifier,flying,denoised,emotional,0.9,0.6,3.12
+    Some fancy name2,second linear classifier,driving,noisy,emotional,0.8,0.6,4.23
+    Some fancy name3,third linear classifier,circling,denoised,non emotional,0.7,0.6,8.46
+    Some fancy name4,fourth linear classifier,moving,noisy,non emotional,0.6,0.6,8.23
+    Some fancy name5,fifth linear classifier,dancing,denoised,emotional,0.4,0.6,9.37
+    Some fancy name6,sixth linear classifier,sliding,noisy,emotional,0.8,0.6,4.32
+    Some fancy name7,seventh linear classifier,walking,denoised,non emotional,0.9,0.6,2.12
+    Some fancy name8,eights linear classifier,diving,noisy,emotional,0.2,0.4,4.32
+    Some fancy name9,ninth linear classifier,strolling,denoised,non emotional,0.5,0.6,2.42
+
+
+
 Nesting
 -------
 


### PR DESCRIPTION
This adds a large table to the table example.

I'm not sure if we really need this for documentation purposes, but it is helpful for testing how the theme can cope with it.

It can test basically two things:

1. How well can we read a table with lots of rows
2. How can we make the whole content of the table visible

For 1. the behavoir is better than expected. Usually I like when every second row is using a different color, like in the RTD tables.
But I also like the insipid approach which looks much better when using with `autosummary`.

For 2. the current behavior is to display a scroll bar at the end of the page, which could have the disadvantage that the user will not find it. So maybe it would be better if the scrollbar would be immediatly below the table and would only scroll the table.

 