### PR TITLE
Use only colors, no underlines for links

### DIFF
--- a/src/insipid_sphinx_theme/insipid/static/insipid.css_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid.css_t
@@ -223,32 +223,34 @@ div.compound > .compound-last {
 /* -- hyperlink styles ------------------------------------------------------ */
 
 a {
-    color: #1863b5;
+    color: #1898b5;
     text-decoration: none;
     overflow-wrap: break-word;
 }
 
 a:hover {
-    text-decoration: underline;
+    color: #008588;
+    text-decoration: none;
 }
 
 a:visited {
-    color: #004188;
+    color: #1898b5;
+    text-decoration: none;
 }
 
 a.external {
+    color: #1863b5;
     text-decoration: none;
-    border-bottom: 1px dotted #1863b5;
 }
 
 a.external:hover {
+    color: #004188;
     text-decoration: none;
-    border-bottom: 1px dotted transparent;
 }
 
 a.external:visited {
+    color: #1863b5;
     text-decoration: none;
-    border-bottom: 1px dotted #004188;
 }
 
 /* -- code formatting ------------------------------------------------------- */


### PR DESCRIPTION
Closes #59 

As described in #59 you would present internal and external links visual different.
I do not really like to use an icon for this, so I decided for a different color for internal links.
I have now removed the underlines completely, and use a darker color when hovering.
Already visited links are not presented in a different color any longer.

![image](https://user-images.githubusercontent.com/173624/139131925-96c33e01-7ab3-4839-a4dc-46ea19d250ef.png)

and repeating the part from the issue from the [external repo](https://github.com/audeering/audmath/):

![image](https://user-images.githubusercontent.com/173624/139132226-c018d6d8-7bf1-485c-97ee-560ec69ef360.png)

---

I'm not completely convinced by th elight blue color for the internal links. But before searching for a better color, I first wanted to get feedback if the overall direction is ok ;)