### PR TITLE
external links: replace border-bottom with underline

### DIFF
--- a/src/insipid_sphinx_theme/insipid/static/insipid.css_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid.css_t
@@ -237,18 +237,15 @@ a:visited {
 }
 
 a.external {
-    text-decoration: none;
-    border-bottom: 1px dotted #1863b5;
+    text-decoration: underline;
 }
 
 a.external:hover {
     text-decoration: none;
-    border-bottom: 1px dotted transparent;
 }
 
 a.external:visited {
     text-decoration: none;
-    border-bottom: 1px dotted #004188;
 }
 
 /* -- code formatting ------------------------------------------------------- */


### PR DESCRIPTION
This is a possible alternative to #62.

It simply replaces the dashed line with an underline.

This makes internal and external links behave in an opposite way: underline is shown on hover for internal links and when not hovering on external links.

This should also avoid the line under images with links, as shown in #59.

Rendered: https://insipid-sphinx-theme--63.org.readthedocs.build/en/63/