### PR TITLE
Set text-size-adjust: none

### DIFF
--- a/src/insipid_sphinx_theme/insipid/static/insipid.css_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid.css_t
@@ -16,6 +16,8 @@ body {
     min-width: {{ theme_body_min_width|todim }};
     color: #000;
     background-color: #fff;
+    text-size-adjust: none;
+    -webkit-text-size-adjust: none;
 }
 
 /* keep the footer at the bottom (on very short pages) */


### PR DESCRIPTION
This avoids font size differences between portrait and landscape modes on smartphones.

Rendered: https://insipid-sphinx-theme--64.org.readthedocs.build/en/64/

Note: on some browsers there is no difference in the first place, so this change has no effect.