### PR TITLE
Make wide images and tables horizontally scrollable

### DIFF
--- a/src/insipid_sphinx_theme/insipid/static/insipid.css_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid.css_t
@@ -174,7 +174,7 @@ blockquote p.attribution {
     text-align: end;
 }
 
-div.figure {
+div.insipid-horizontally-scrollable {
     overflow-x: auto;
 }
 

--- a/src/insipid_sphinx_theme/insipid/static/insipid.js
+++ b/src/insipid_sphinx_theme/insipid/static/insipid.js
@@ -8,6 +8,20 @@ $(document).ready(function () {
     var $topbar = $('#topbar');
     var $topbar_placeholder = $('#topbar-placeholder');
 
+    // make large images and tables horizontally scrollable
+    document.querySelectorAll(
+        'table.docutils:not(.field-list,.footnote,.citation), div.body img'
+    ).forEach(el => {
+        // Avoid wrapping <img> inside <a>, wrap parent instead:
+        if (!(el.previousSibling || el.nextSibling)) {
+            el = el.parentNode;
+        }
+        let wrapper = document.createElement('div');
+        wrapper.classList.add('insipid-horizontally-scrollable');
+        el.parentNode.insertBefore(wrapper, el);
+        wrapper.appendChild(el);
+    });
+
     const threshold = 10;
 
     // auto-hide topbar


### PR DESCRIPTION
See #61.

This avoids horizontal scrollbars around the whole text.

Rendered:
* https://insipid-sphinx-theme--66.org.readthedocs.build/en/66/showcase/images.html#scaled-image
* https://insipid-sphinx-theme--66.org.readthedocs.build/en/66/showcase/tables.html#large-table