### PR TITLE
Make wide tables horizontally scrollable, revert special <img> handling

### DIFF
--- a/src/insipid_sphinx_theme/insipid/static/insipid.css_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid.css_t
@@ -199,10 +199,6 @@ hr.docutils {
     border-top: solid 1px #ccc;
 }
 
-img {
-    max-width: unset;
-}
-
 div.compound {
     margin-top: 1em;
     margin-bottom: 1em;
@@ -708,10 +704,6 @@ body.js.sidebar-visible > .sidebar-resize-handle {
 
 body.js:not(.sidebar-visible) .sphinxsidebar {
     {{ sidebar_side }}: calc(0px - var(--sidebar-width));
-}
-
-div.sphinxsidebar img {
-    max-width: 100%;
 }
 
 div.sphinxsidebar h3 {

--- a/src/insipid_sphinx_theme/insipid/static/insipid.css_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid.css_t
@@ -174,7 +174,7 @@ blockquote p.attribution {
     text-align: end;
 }
 
-div.figure {
+div.insipid-horizontally-scrollable {
     overflow-x: auto;
 }
 

--- a/src/insipid_sphinx_theme/insipid/static/insipid.js
+++ b/src/insipid_sphinx_theme/insipid/static/insipid.js
@@ -8,6 +8,16 @@ $(document).ready(function () {
     var $topbar = $('#topbar');
     var $topbar_placeholder = $('#topbar-placeholder');
 
+    // make large tables horizontally scrollable
+    document.querySelectorAll(
+        'table.docutils:not(.field-list,.footnote,.citation)'
+    ).forEach(el => {
+        let wrapper = document.createElement('div');
+        wrapper.classList.add('insipid-horizontally-scrollable');
+        el.parentNode.insertBefore(wrapper, el);
+        wrapper.appendChild(el);
+    });
+
     const threshold = 10;
 
     // auto-hide topbar


### PR DESCRIPTION
This supersedes and closes #66, see also #61.

This restores the `<img>` handling of the `basic` theme, making images behave like in most themes.

This has the disadvantage that images that are heavily scaled up (with `:scale:`) will become distorted.
This is bad, but I don't know a good solution, and all Sphinx themes seem to have that same problem.

Rendered:

* https://insipid-sphinx-theme--68.org.readthedocs.build/en/68/showcase/tables.html#large-table
* https://insipid-sphinx-theme--68.org.readthedocs.build/en/68/showcase/images.html#scaled-image