### PR TITLE
Toggleable sidebar without JavaScript ...

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -36,6 +36,7 @@ html_theme_options = {
     #'breadcrumbs': True,
     #'globaltoc_collapse': False,
     #'globaltoc_includehidden': True,
+    #'initial_sidebar_visibility_threshold': None,
     #'left_buttons': [
     #],
     #'navigation_with_keys': False,

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -51,6 +51,16 @@ See below for `default values`_.
     at the top of each page
     (via the :gh-template:`page.html` template).
 
+.. theme-option:: initial_sidebar_visibility_threshold
+
+    The visibility of the sidebar depends on the setting from the previous
+    visit, which is stored in the browser's ``localStorage``.
+    If no information is available (i.e., on the first visit),
+    the sidebar is hidden, except if the browser window is wider
+    than the given threshold (in pixels or any CSS unit).
+    If ``None`` is given, or if JavaScript is disabled in the browser,
+    the sidebar is initially hidden, regardless of screen width.
+
 .. theme-option:: left_buttons
 
     List of templates to show on the left side of the title bar.

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -54,6 +54,9 @@ boring
     Most navigational tools can be hidden (and are in fact hidden by default),
     providing a maximum of screen real estate for
     and a minimum of distraction from your content.
+    Only if your browser window is extremely wide, the sidebar will be shown
+    on the initial visit.  This can be configured with
+    :theme-option:`initial_sidebar_visibility_threshold`.
 
 accessible
     *Help needed!*
@@ -155,7 +158,7 @@ keyboard navigation
 
     You can switch between pages using the left and right arrow keys.
     This feature can be disabled with :theme-option:`navigation_with_keys`.
-    
+
     In addition to the left/right arrow keys,
     several key combinations are provided using the ``accesskey`` HTML feature.
     The way to use these keyboard shortcuts depends on the browser
@@ -193,7 +196,7 @@ support for https://readthedocs.org/
     The RTD "badge" (for selecting versions, languages etc.)
     is incorporated into the bottom of the ``insipid`` sidebar
     (instead of floating around in the bottom right corner of the page).
-   
+
     Furthermore, a link to the connected Bitbucket/Github/GitLab repository
     is automatically displayed in the topbar.
     This can be disabled by overriding :theme-option:`right_buttons`.

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -7,6 +7,7 @@ Some further ideas were stolen from the Sphinx themes
 sphinx_typlog_theme_ (https://readthedocs.org/ badge),
 sphinx_material_ (previous/next arrows in relbar),
 sphinx_book_theme_ (fullscreen button),
+furo_ (sidebar that can be toggled without JavaScript),
 as well as websites like
 Github_,
 MDN_,
@@ -27,6 +28,7 @@ __ https://github.com/search?q=sphinx+theme
 .. _sphinx_typlog_theme: https://sphinx-typlog-theme.readthedocs.io/
 .. _sphinx_material: https://bashtage.github.io/sphinx-material/
 .. _sphinx_book_theme: https://sphinx-book-theme.readthedocs.io/
+.. _furo: https://pradyunsg.me/furo/quickstart/
 .. _Github: https://github.com/
 .. _MDN: https://developer.mozilla.org/en-US/docs/Web
 
@@ -82,11 +84,13 @@ support for right-to-left languages
     except for a measly :theme-option:`rightsidebar` theme option.
 
 optional JavaScript
-    Some features (like hiding/resizing navigational tools, search,
+    Some features (like resizing the sidebar, storing the sidebar state when
+    navigating between pages, hiding/showing the topbar, search,
     fullscreen button) require JavaScript.
     However, if JavaScript is disabled,
     all content should still be perfectly readable and the navigation within
-    and between pages should still work reasonably well.
+    and between pages should still work well.
+    Even opening and closing the sidebar works without JavaScript.
 
 support for *all* Sphinx features
     The largest part of this documentation

--- a/src/insipid_sphinx_theme/insipid/home.html
+++ b/src/insipid_sphinx_theme/insipid/home.html
@@ -1,5 +1,5 @@
 {# To be used in html_sidebars #}
 <p class="insipid-icon" style="text-align: center; font-weight: bold;">
-  <a class="reference internal" href="{{ pathto(master_doc) }}"">{% include 'icons/home.svg' %}
+  <a class="reference internal" href="{{ pathto(master_doc) }}">{% include 'icons/home.svg' %}
 {{ project|e }}</a>
 </p>

--- a/src/insipid_sphinx_theme/insipid/layout.html
+++ b/src/insipid_sphinx_theme/insipid/layout.html
@@ -71,39 +71,43 @@
 {%- endblock %}
 
 
-{% block body_tag %}
-  <body{% if render_sidebar %} class="sidebar-visible"{% endif %}>
-{%- endblock %}
-
-
 {% block header %}
     <script type="text/javascript">
-        (function() {
-            var $body = $(document.body);
-            $body.addClass('js');
-{%- if render_sidebar %}
-            $body.addClass('sidebar-resizing');  // avoid transitions on load
-            $body.removeClass('sidebar-visible');
-            try {
-                var sidebar = localStorage.getItem('sphinx-sidebar');
-                if (sidebar === 'visible') {
-                    $body.addClass('sidebar-visible');
-                }
-                var sidebar_width = localStorage.getItem('sphinx-sidebar-width');
-                if (sidebar_width) {
-                    $(':root').css('--sidebar-width', sidebar_width);
-                }
-            } catch(e) {
-            }
-{%- if pagename == "search" %}
-            // hide sidebar on narrow screen
-            if ($body.css('overflow') === 'hidden') {
-                $body.removeClass('sidebar-visible');
-            }
-{%- endif %}
-{%- endif %}
-        })();
+        document.body.classList.add('js');
     </script>
+{%- if render_sidebar %}
+    <input type="checkbox" id="sidebar-checkbox" style="display: none;">
+    <div class="sidebar-resize-handle"></div>
+    <label id="overlay" for="sidebar-checkbox"></label>
+    <script type="text/javascript">
+        try {
+            let sidebar = localStorage.getItem('sphinx-sidebar');
+            const sidebar_width = localStorage.getItem('sphinx-sidebar-width');
+            if (sidebar_width) {
+                document.documentElement.style.setProperty('--sidebar-width', sidebar_width);
+            }
+{%- if theme_initial_sidebar_visibility_threshold != None %}
+            // show sidebar on wide screen
+            if (!sidebar && window.matchMedia('(min-width: {{ theme_initial_sidebar_visibility_threshold|todim }})').matches) {
+                sidebar = 'visible';
+                // NB: We don't store the value in localStorage!
+            }
+{%- endif %}
+{%- if pagename == "search" and theme_sidebar_overlay_width != None %}
+            // hide sidebar on narrow screen
+            if (sidebar === 'visible' && window.matchMedia('(max-width: {{ theme_sidebar_overlay_width|todim }})').matches) {
+                localStorage.removeItem('sphinx-sidebar');
+                sidebar = 'hidden';
+            }
+{%- endif %}
+            if (sidebar === 'visible') {
+                document.getElementById('sidebar-checkbox').checked = true;
+            }
+        } catch(e) {
+            console.info(e);
+        }
+    </script>
+{%- endif %}
     <header id="topbar-placeholder">
       <div id="topbar">
         <div id="titlebar">
@@ -199,12 +203,6 @@
 {%- endblock %}
 
 
-{% block sidebar1 %}{% endblock %}
-
-
-{% block sidebar2 %}{% endblock %}
-
-
 {% block relbar2 %}
 {{ insipid_relbar() }}
 {%- endblock %}
@@ -216,12 +214,7 @@
 {% block comments %}{% endblock %}
 </div>
 {% endif%}
-{{ sidebar() }}
 {% include 'footer.html' %}
-{%- if render_sidebar %}
-    <div class="sidebar-resize-handle"></div>
-    <div id="overlay"></div>
-{%- endif %}
 {%- endblock %}
 
 

--- a/src/insipid_sphinx_theme/insipid/layout.html
+++ b/src/insipid_sphinx_theme/insipid/layout.html
@@ -77,8 +77,8 @@
     </script>
 {%- if render_sidebar %}
     <input type="checkbox" id="sidebar-checkbox" style="display: none;">
-    <div class="sidebar-resize-handle"></div>
     <label id="overlay" for="sidebar-checkbox"></label>
+    <div class="sidebar-resize-handle"></div>
     <script type="text/javascript">
         try {
             let sidebar = localStorage.getItem('sphinx-sidebar');

--- a/src/insipid_sphinx_theme/insipid/sidebar-button.html
+++ b/src/insipid_sphinx_theme/insipid/sidebar-button.html
@@ -1,6 +1,6 @@
 {# NB: "title" and some ARIA attributes are set via JavaScript. #}
 {%- if render_sidebar %}
-            <button id="sidebar-button" type="button" aria-controls="sphinxsidebar" accesskey="M">
+            <label for="sidebar-checkbox" id="sidebar-button" tabindex="0" aria-controls="sphinxsidebar" accesskey="M">
               {% include 'icons/menu.svg' %}
-            </button>
+            </label>
 {%- endif %}

--- a/src/insipid_sphinx_theme/insipid/static/insipid-sidebar-readthedocs.css_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid-sidebar-readthedocs.css_t
@@ -15,7 +15,7 @@ div.sphinxsidebar {
     max-width: unset;
 }
 
-body.js:not(.sidebar-visible) .injected .rst-versions.rst-badge {
+#sidebar-checkbox:not(:checked) ~ .injected .rst-versions.rst-badge {
     {{ sidebar_side }}: calc(0px - var(--sidebar-width));
 }
 
@@ -35,13 +35,13 @@ body.js:not(.sidebar-visible) .injected .rst-versions.rst-badge {
     width: 100%;
 }
 
-body:not(.sidebar-visible) .ethical-fixedfooter {
+#sidebar-checkbox:not(:checked) ~ .ethical-fixedfooter {
     left: 0;
     right: 0;
     width: unset;
 }
 
-body.sidebar-visible .ethical-fixedfooter {
+#sidebar-checkbox:checked ~ .ethical-fixedfooter {
     {%- if theme_rightsidebar|tobool %}
     left: 0;
     right: var(--sidebar-width);
@@ -52,8 +52,8 @@ body.sidebar-visible .ethical-fixedfooter {
     width: unset;
 }
 
-body.js:not(.sidebar-resizing) .rst-versions.rst-badge,
-body.js:not(.sidebar-resizing) .ethical-fixedfooter {
+body:not(.sidebar-resizing) .rst-versions.rst-badge,
+body:not(.sidebar-resizing) .ethical-fixedfooter {
     transition: {{ sidebar_side }} {{ theme_sidebar_transition }};
 }
 

--- a/src/insipid_sphinx_theme/insipid/static/insipid-sidebar.js_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid-sidebar.js_t
@@ -80,7 +80,7 @@
     }
 
     sidebar_button.addEventListener('keydown', event => {
-        if (event.code == 'Enter' || event.code == 'Space') {
+        if (event.code === 'Enter' || event.code === 'Space') {
             sidebar_button.click();
             event.preventDefault();
         }
@@ -277,7 +277,7 @@
         }
     })
 
-    if ($current.length == 1 && $current[0].childElementCount == 1 && small_screen.matches) {
+    if ($current.length === 1 && $current[0].childElementCount === 1 && small_screen.matches) {
         hide();
     }
 {%- endif %}

--- a/src/insipid_sphinx_theme/insipid/static/insipid-sidebar.js_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid-sidebar.js_t
@@ -6,6 +6,7 @@
     const sidebar_checkbox = document.getElementById('sidebar-checkbox');
     const topbar = document.getElementById('topbar');
     const overlay = document.getElementById('overlay');
+    const root = document.documentElement;
 
     sidebar.setAttribute('id', 'sphinxsidebar');  // for aria-controls
 
@@ -15,10 +16,6 @@
         } else {
             return window.getComputedStyle(this).getPropertyValue(name);
         }
-    }
-
-    function css_variable(name, ...value) {
-        return document.documentElement.css(name, ...value);
     }
 
     function updateSidebarAttributesVisible() {
@@ -157,9 +154,9 @@
         var width = {% if theme_rightsidebar|tobool -%}
             window_width - {% endif %}e.clientX;
         if (width > window_width) {
-            css_variable('--sidebar-width', window_width + 'px');
+            root.css('--sidebar-width', window_width + 'px');
         } else if (width > 10) {
-            css_variable('--sidebar-width', width + 'px');
+            root.css('--sidebar-width', width + 'px');
         } else {
             ignore_resize = true;
             hide();
@@ -178,10 +175,10 @@
 
     function stop_resize_base() {
         if (ignore_resize) {
-            css_variable('--sidebar-width', '{{ theme_sidebarwidth|todim }}');
+            root.css('--sidebar-width', '{{ theme_sidebarwidth|todim }}');
             ignore_resize = false;
         }
-        store('sphinx-sidebar-width', css_variable('--sidebar-width'));
+        store('sphinx-sidebar-width', root.css('--sidebar-width'));
         document.body.classList.remove('sidebar-resizing');
     }
 
@@ -204,7 +201,7 @@
     $(window).on('resize', function () {
         const window_width = window.innerWidth;
         if (window_width < sidebar.offsetWidth) {
-            css_variable('--sidebar-width', window_width + 'px');
+            root.css('--sidebar-width', window_width + 'px');
         }
     });
 
@@ -218,7 +215,7 @@
                 } else {
                     height = entry.contentRect.height;
                 }
-                css_variable('--topbar-height', height + 'px');
+                root.css('--topbar-height', height + 'px');
             }
         });
         resizeObserver.observe(topbar);
@@ -240,12 +237,12 @@
                         } else {
                             height = entry.contentRect.height;
                         }
-                        css_variable('--readthedocs-badge-height', height + 'px');
+                        root.css('--readthedocs-badge-height', height + 'px');
                     }
                 });
                 resizeObserver.observe(badge);
             } else {
-                css_variable('--readthedocs-badge-height', badge.offsetHeight + 'px');
+                root.css('--readthedocs-badge-height', badge.offsetHeight + 'px');
             }
         }
     };

--- a/src/insipid_sphinx_theme/insipid/static/insipid-sidebar.js_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid-sidebar.js_t
@@ -1,38 +1,43 @@
-$(document).ready(function () {
+(function() { function dom_loaded() {
     'use strict';
-    var $root = $(':root');
-    var $body = $(document.body);
-    var $overlay = $('#overlay');
-    var $sidebar = $('.sphinxsidebar').first();
-    var $sidebar_tabbable = $sidebar.find(':input, a[href], area[href], iframe');
-    var $sidebar_button = $('#sidebar-button');
+    const sidebar = document.querySelector('.sphinxsidebar');
+    const sidebar_tabbable = sidebar.querySelectorAll('input, textarea, select, button, a[href], area[href], iframe');
+    const sidebar_button = document.getElementById('sidebar-button');
+    const sidebar_checkbox = document.getElementById('sidebar-checkbox');
+    const topbar = document.getElementById('topbar');
+    const overlay = document.getElementById('overlay');
 
-    $body.removeClass('sidebar-resizing');
+    sidebar.setAttribute('id', 'sphinxsidebar');  // for aria-controls
 
-    $sidebar.attr('id', 'sphinxsidebar');  // for aria-controls
+    Element.prototype.css = function (name, ...value) {
+        if (value.length) {
+            this.style.setProperty(name, ...value);
+        } else {
+            return window.getComputedStyle(this).getPropertyValue(name);
+        }
+    }
+
+    function css_variable(name, ...value) {
+        return document.documentElement.css(name, ...value);
+    }
 
     function updateSidebarAttributesVisible() {
-        $sidebar_button.attr('title', "{{ _('Collapse sidebar') }}");
-        $sidebar_button.attr('aria-label', "{{ _('Collapse sidebar') }}");
-        $sidebar_button.attr('aria-expanded', true);
-        $sidebar.attr('aria-hidden', false);
-        $sidebar_tabbable.attr('tabindex', 0);
+        sidebar_button.setAttribute('title', "{{ _('Collapse sidebar') }}");
+        sidebar_button.setAttribute('aria-label', "{{ _('Collapse sidebar') }}");
+        sidebar_button.setAttribute('aria-expanded', true);
+        sidebar.setAttribute('aria-hidden', false);
+        sidebar_tabbable.forEach(el => { el.setAttribute('tabindex', 0); });
     }
 
     function updateSidebarAttributesHidden() {
-        $sidebar_button.attr('title', "{{ _('Expand sidebar') }}");
-        $sidebar_button.attr('aria-label', "{{ _('Expand sidebar') }}");
-        $sidebar_button.attr('aria-expanded', false);
-        $sidebar.attr('aria-hidden', true);
-        $sidebar_tabbable.attr('tabindex', -1);
+        sidebar_button.setAttribute('title', "{{ _('Expand sidebar') }}");
+        sidebar_button.setAttribute('aria-label', "{{ _('Expand sidebar') }}");
+        sidebar_button.setAttribute('aria-expanded', false);
+        sidebar.setAttribute('aria-hidden', true);
+        sidebar_tabbable.forEach(el => { el.setAttribute('tabindex', -1); });
     }
 
-    $sidebar.attr('tabindex', -1);
-    if ($body.hasClass('sidebar-visible')) {
-        updateSidebarAttributesVisible();
-    } else {
-        updateSidebarAttributesHidden();
-    }
+    sidebar.setAttribute('tabindex', -1);
 
     function store(key, value) {
         try {
@@ -41,45 +46,41 @@ $(document).ready(function () {
         }
     }
 
-    function showSidebar() {
-        $body.addClass('sidebar-visible');
+    sidebar_checkbox.addEventListener('change', (event) => {
+        if (event.target.checked) {
+            updateSidebarAttributesVisible();
+            store('sphinx-sidebar', 'visible');
+            document.body.classList.remove('topbar-folded');
+            sidebar.focus({preventScroll: true});
+            sidebar.blur();
+        } else {
+            updateSidebarAttributesHidden();
+            store('sphinx-sidebar', 'hidden');
+            if (document.scrollingElement.scrollTop < topbar.offsetHeight) {
+                document.body.classList.remove('topbar-folded');
+            } else {
+                document.body.classList.add('topbar-folded');
+            }
+            document.scrollingElement.focus({preventScroll: true});
+            document.scrollingElement.blur();
+        }
+    });
+
+    if (sidebar_checkbox.checked) {
         updateSidebarAttributesVisible();
-        store('sphinx-sidebar', 'visible');
-        $body.removeClass('topbar-folded');
-        $sidebar[0].focus({preventScroll: true});
-        $sidebar.blur();
-    }
-
-    function hideSidebar() {
-        $body.removeClass('sidebar-visible');
+    } else {
         updateSidebarAttributesHidden();
-        store('sphinx-sidebar', 'hidden');
-        if (document.scrollingElement.scrollTop < $('#topbar').height()) {
-            $body.removeClass('topbar-folded');
-        } else {
-            $body.addClass('topbar-folded');
-        }
-        document.scrollingElement.focus({preventScroll: true});
-        document.scrollingElement.blur();
     }
 
-    $sidebar_button.on('click', function () {
-        if ($body.hasClass('sidebar-visible')) {
-            $sidebar_button.blur();
-            hideSidebar();
-        } else {
-            showSidebar();
-        }
-    });
+    function hide() {
+        sidebar_checkbox.checked = false;
+        sidebar_checkbox.dispatchEvent(new Event('change'));
+    }
 
-    $sidebar_button.on('touchend', function ($event) {
-        $('#topbar-placeholder').removeClass('fake-hover');
-        $event.stopPropagation();
-    });
-
-    $overlay.on('click', function () {
-        if ($body.hasClass('sidebar-visible')) {
-            hideSidebar();
+    sidebar_button.addEventListener('keydown', function (e) {
+        if (e.code == 'Enter' || e.code == 'Space') {
+            sidebar_button.click();
+            e.preventDefault();
         }
     });
 
@@ -89,9 +90,9 @@ $(document).ready(function () {
         if (e.touches.length > 1) { return; }
         var touch = e.touches[0];
         {%- if theme_rightsidebar|tobool %}
-        if (touch.clientX >= $(window).width() - $sidebar.width()) {
+        if (touch.clientX >= window.innerWidth - sidebar.offsetWidth) {
         {%- else %}
-        if (touch.clientX <= $sidebar.width()) {
+        if (touch.clientX <= sidebar.offsetWidth) {
         {%- endif %}
             touchstart = {
                 x: touch.clientX,
@@ -119,12 +120,13 @@ $(document).ready(function () {
             {%- else %}
             if (x_diff > 0) {
             {%- endif %}
-                if (!$body.hasClass('sidebar-visible')) {
-                    showSidebar();
+                if (!sidebar_checkbox.checked) {
+                    sidebar_checkbox.checked = true;
+                    sidebar_checkbox.dispatchEvent(new Event('change'));
                 }
             } else {
-                if ($body.hasClass('sidebar-visible')) {
-                    hideSidebar();
+                if (sidebar_checkbox.checked) {
+                    hide();
                 }
             }
         }
@@ -134,7 +136,7 @@ $(document).ready(function () {
     $('.sidebar-resize-handle').on('mousedown', function (e) {
         $(window).on('mousemove', resize_mouse);
         $(window).on('mouseup', stop_resize_mouse);
-        $body.addClass('sidebar-resizing');
+        document.body.classList.add('sidebar-resizing');
         return false;  // Prevent unwanted text selection while resizing
     });
 
@@ -143,7 +145,7 @@ $(document).ready(function () {
         if (e.touches.length > 1) { return; }
         $(window).on('touchmove', resize_touch);
         $(window).on('touchend', stop_resize_touch);
-        $body.addClass('sidebar-resizing');
+        document.body.classList.add('sidebar-resizing');
         return false;  // Prevent unwanted text selection while resizing
     });
 
@@ -151,16 +153,16 @@ $(document).ready(function () {
 
     function resize_base(e) {
         if (ignore_resize) { return; }
-        var window_width = $(window).width();
+        var window_width = window.innerWidth;
         var width = {% if theme_rightsidebar|tobool -%}
             window_width - {% endif %}e.clientX;
         if (width > window_width) {
-            $root.css('--sidebar-width', window_width + 'px');
+            css_variable('--sidebar-width', window_width + 'px');
         } else if (width > 10) {
-            $root.css('--sidebar-width', width + 'px');
+            css_variable('--sidebar-width', width + 'px');
         } else {
             ignore_resize = true;
-            hideSidebar();
+            hide();
         }
     }
 
@@ -176,11 +178,11 @@ $(document).ready(function () {
 
     function stop_resize_base() {
         if (ignore_resize) {
-            $root.css('--sidebar-width', '{{ theme_sidebarwidth|todim }}');
+            css_variable('--sidebar-width', '{{ theme_sidebarwidth|todim }}');
             ignore_resize = false;
         }
-        store('sphinx-sidebar-width', $root.css('--sidebar-width'));
-        $body.removeClass('sidebar-resizing');
+        store('sphinx-sidebar-width', css_variable('--sidebar-width'));
+        document.body.classList.remove('sidebar-resizing');
     }
 
     function stop_resize_mouse(e) {
@@ -200,9 +202,9 @@ $(document).ready(function () {
     }
 
     $(window).on('resize', function () {
-        var window_width = $(window).width();
-        if (window_width < $sidebar.width()) {
-            $root.css('--sidebar-width', window_width + 'px');
+        const window_width = window.innerWidth;
+        if (window_width < sidebar.offsetWidth) {
+            css_variable('--sidebar-width', window_width + 'px');
         }
     });
 
@@ -216,10 +218,10 @@ $(document).ready(function () {
                 } else {
                     height = entry.contentRect.height;
                 }
-                $root.css('--topbar-height', height + 'px');
+                css_variable('--topbar-height', height + 'px');
             }
         });
-        resizeObserver.observe(document.getElementById('topbar'));
+        resizeObserver.observe(topbar);
     }
 
 {%- if READTHEDOCS|tobool %}
@@ -238,12 +240,12 @@ $(document).ready(function () {
                         } else {
                             height = entry.contentRect.height;
                         }
-                        $root.css('--readthedocs-badge-height', height + 'px');
+                        css_variable('--readthedocs-badge-height', height + 'px');
                     }
                 });
                 resizeObserver.observe(badge);
             } else {
-                $root.css('--readthedocs-badge-height', badge.offsetHeight + 'px');
+                css_variable('--readthedocs-badge-height', badge.offsetHeight + 'px');
             }
         }
     };
@@ -251,26 +253,40 @@ $(document).ready(function () {
 {%- endif %}
 
     var $current = $('.sphinxsidebar *:has(> a[href^="#"])');
+{# Possible non-jQuery replacement:
+    const current = Array.from(document.querySelectorAll('.sphinxsidebar *')).filter(e => e.querySelector(':scope > a[href^="#"]'));
+#}
+
     $current.addClass('current-page');
     if ($current.length) {
         var top = $current.offset().top;
         var height = $current.height();
-        var topbar_height = $('#topbar').height();
-        if (top < topbar_height || top + height > $sidebar.height()) {
+        const topbar_height = topbar.offsetHeight;
+        if (top < topbar_height || top + height > sidebar.offsetHeight) {
             $current[0].scrollIntoView(true);
         }
     }
 
+{%- if theme_sidebar_overlay_width != None %}
+    const small_screen = window.matchMedia('(max-width: {{ theme_sidebar_overlay_width|todim }})');
+
     $current.on('click', '> a', function () {
-        if ($overlay.css('position') === 'fixed') {
-            hideSidebar();
+        if (small_screen.matches) {
+            hide();
         }
     })
 
-    if ($current.length == 1 && $current[0].childElementCount == 1 && $overlay.css('position') === 'fixed') {
-        hideSidebar();
+    if ($current.length == 1 && $current[0].childElementCount == 1 && small_screen.matches) {
+        hide();
     }
-});
+{%- endif %}
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', dom_loaded);
+} else {
+    dom_loaded();
+}})();
 
 {#
 vim:ft=javascript

--- a/src/insipid_sphinx_theme/insipid/static/insipid-sidebar.js_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid-sidebar.js_t
@@ -1,4 +1,4 @@
-(function() { function dom_loaded() {
+(() => { function dom_loaded() {
     'use strict';
     const sidebar = document.querySelector('.sphinxsidebar');
     const sidebar_tabbable = sidebar.querySelectorAll('input, textarea, select, button, a[href], area[href], iframe');
@@ -23,7 +23,7 @@
         sidebar_button.setAttribute('aria-label', "{{ _('Collapse sidebar') }}");
         sidebar_button.setAttribute('aria-expanded', true);
         sidebar.setAttribute('aria-hidden', false);
-        sidebar_tabbable.forEach(el => { el.setAttribute('tabindex', 0); });
+        sidebar_tabbable.forEach(el => el.setAttribute('tabindex', 0));
     }
 
     function updateSidebarAttributesHidden() {
@@ -31,7 +31,7 @@
         sidebar_button.setAttribute('aria-label', "{{ _('Expand sidebar') }}");
         sidebar_button.setAttribute('aria-expanded', false);
         sidebar.setAttribute('aria-hidden', true);
-        sidebar_tabbable.forEach(el => { el.setAttribute('tabindex', -1); });
+        sidebar_tabbable.forEach(el => el.setAttribute('tabindex', -1));
     }
 
     sidebar.setAttribute('tabindex', -1);
@@ -43,7 +43,7 @@
         }
     }
 
-    sidebar_checkbox.addEventListener('change', (event) => {
+    sidebar_checkbox.addEventListener('change', event => {
         if (event.target.checked) {
             updateSidebarAttributesVisible();
             store('sphinx-sidebar', 'visible');
@@ -69,23 +69,28 @@
         updateSidebarAttributesHidden();
     }
 
+    function show() {
+        sidebar_checkbox.checked = true;
+        sidebar_checkbox.dispatchEvent(new Event('change'));
+    }
+
     function hide() {
         sidebar_checkbox.checked = false;
         sidebar_checkbox.dispatchEvent(new Event('change'));
     }
 
-    sidebar_button.addEventListener('keydown', function (e) {
-        if (e.code == 'Enter' || e.code == 'Space') {
+    sidebar_button.addEventListener('keydown', event => {
+        if (event.code == 'Enter' || event.code == 'Space') {
             sidebar_button.click();
-            e.preventDefault();
+            event.preventDefault();
         }
     });
 
     var touchstart;
 
-    document.addEventListener('touchstart', function (e) {
-        if (e.touches.length > 1) { return; }
-        var touch = e.touches[0];
+    document.addEventListener('touchstart', event => {
+        if (event.touches.length > 1) { return; }
+        var touch = event.touches[0];
         {%- if theme_rightsidebar|tobool %}
         if (touch.clientX >= window.innerWidth - sidebar.offsetWidth) {
         {%- else %}
@@ -99,13 +104,13 @@
         }
     });
 
-    document.addEventListener('touchend', function (e) {
+    document.addEventListener('touchend', event => {
         if (!touchstart) { return; }
-        if (e.touches.length > 0 || e.changedTouches.length > 1) {
+        if (event.touches.length > 0 || event.changedTouches.length > 1) {
             touchstart = null;
             return;
         }
-        var touch = e.changedTouches[0];
+        var touch = event.changedTouches[0];
         var x = touch.clientX;
         var y = touch.clientY;
         var x_diff = x - touchstart.x;
@@ -118,8 +123,7 @@
             if (x_diff > 0) {
             {%- endif %}
                 if (!sidebar_checkbox.checked) {
-                    sidebar_checkbox.checked = true;
-                    sidebar_checkbox.dispatchEvent(new Event('change'));
+                    show();
                 }
             } else {
                 if (sidebar_checkbox.checked) {
@@ -130,16 +134,16 @@
         touchstart = null;
     });
 
-    $('.sidebar-resize-handle').on('mousedown', function (e) {
+    $('.sidebar-resize-handle').on('mousedown', event => {
         $(window).on('mousemove', resize_mouse);
         $(window).on('mouseup', stop_resize_mouse);
         document.body.classList.add('sidebar-resizing');
         return false;  // Prevent unwanted text selection while resizing
     });
 
-    $('.sidebar-resize-handle').on('touchstart', function (e) {
-        e = e.originalEvent;
-        if (e.touches.length > 1) { return; }
+    $('.sidebar-resize-handle').on('touchstart', event => {
+        event = event.originalEvent;
+        if (event.touches.length > 1) { return; }
         $(window).on('touchmove', resize_touch);
         $(window).on('touchend', stop_resize_touch);
         document.body.classList.add('sidebar-resizing');
@@ -148,11 +152,11 @@
 
     var ignore_resize = false;
 
-    function resize_base(e) {
+    function resize_base(event) {
         if (ignore_resize) { return; }
         var window_width = window.innerWidth;
         var width = {% if theme_rightsidebar|tobool -%}
-            window_width - {% endif %}e.clientX;
+            window_width - {% endif %}event.clientX;
         if (width > window_width) {
             root.css('--sidebar-width', window_width + 'px');
         } else if (width > 10) {
@@ -163,14 +167,14 @@
         }
     }
 
-    function resize_mouse(e) {
-        resize_base(e.originalEvent);
+    function resize_mouse(event) {
+        resize_base(event.originalEvent);
     }
 
-    function resize_touch(e) {
-        e = e.originalEvent;
-        if (e.touches.length > 1) { return; }
-        resize_base(e.touches[0]);
+    function resize_touch(event) {
+        event = event.originalEvent;
+        if (event.touches.length > 1) { return; }
+        resize_base(event.touches[0]);
     }
 
     function stop_resize_base() {
@@ -182,15 +186,15 @@
         document.body.classList.remove('sidebar-resizing');
     }
 
-    function stop_resize_mouse(e) {
+    function stop_resize_mouse(event) {
         $(window).off('mousemove', resize_mouse);
         $(window).off('mouseup', stop_resize_mouse);
         stop_resize_base();
     }
 
-    function stop_resize_touch(e) {
-        e = e.originalEvent;
-        if (e.touches.length > 0 || e.changedTouches.length > 1) {
+    function stop_resize_touch(event) {
+        event = event.originalEvent;
+        if (event.touches.length > 0 || event.changedTouches.length > 1) {
             return;
         }
         $(window).off('touchmove', resize_touch);
@@ -198,7 +202,7 @@
         stop_resize_base();
     }
 
-    $(window).on('resize', function () {
+    $(window).on('resize', () => {
         const window_width = window.innerWidth;
         if (window_width < sidebar.offsetWidth) {
             root.css('--sidebar-width', window_width + 'px');
@@ -251,7 +255,7 @@
 
     var $current = $('.sphinxsidebar *:has(> a[href^="#"])');
 {# Possible non-jQuery replacement:
-    const current = Array.from(document.querySelectorAll('.sphinxsidebar *')).filter(e => e.querySelector(':scope > a[href^="#"]'));
+    const current = Array.from(document.querySelectorAll('.sphinxsidebar *')).filter(el => el.querySelector(':scope > a[href^="#"]'));
 #}
 
     $current.addClass('current-page');
@@ -267,7 +271,7 @@
 {%- if theme_sidebar_overlay_width != None %}
     const small_screen = window.matchMedia('(max-width: {{ theme_sidebar_overlay_width|todim }})');
 
-    $current.on('click', '> a', function () {
+    $current.on('click', '> a', () => {
         if (small_screen.matches) {
             hide();
         }

--- a/src/insipid_sphinx_theme/insipid/static/insipid.css_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid.css_t
@@ -36,7 +36,7 @@ div.body {
     line-height: 1.618;
 }
 
-body.js * {
+* {
     scroll-margin-top: var(--topbar-height);
     scroll-snap-margin-top: var(--topbar-height);  /* Safari */
 }
@@ -650,15 +650,19 @@ div.sphinxsidebar {
     overscroll-behavior: contain;
 }
 
-body.sidebar-visible {
+#sidebar-checkbox:checked ~ div.document,
+#sidebar-checkbox:checked ~ .relbar,
+#sidebar-checkbox:checked ~ footer {
     margin-{{ sidebar_side }}: var(--sidebar-width);
 }
 
-body.js:not(.sidebar-resizing) {
+body:not(.sidebar-resizing) div.document,
+body:not(.sidebar-resizing) .relbar,
+body:not(.sidebar-resizing) footer {
     transition: margin-{{ sidebar_side }} {{ theme_sidebar_transition }};
 }
 
-body.js:not(.sidebar-resizing) .sphinxsidebar {
+body:not(.sidebar-resizing) .sphinxsidebar {
     transition: {{ sidebar_side }} {{ theme_sidebar_transition }};
 }
 
@@ -684,7 +688,8 @@ div.sphinxsidebarwrapper > :last-child {
     bottom: 0;
 }
 
-body.js.sidebar-visible .sidebar-resize-handle {
+body.js #sidebar-checkbox:checked ~ .sidebar-resize-handle,
+body.js #sidebar-checkbox:checked ~ div.document .sidebar-resize-handle {
     display: block;
     cursor: col-resize;
     width: 10px;
@@ -698,11 +703,12 @@ body.js.sidebar-visible .sidebar-resize-handle {
     {%- endif %}
 }
 
-body.js.sidebar-visible > .sidebar-resize-handle {
-    {{ sidebar_side }}: 0;
+body.js #sidebar-checkbox:checked ~ .sidebar-resize-handle {
+    z-index: 390;{# same as sidebar #}
+    {{ sidebar_side }}: var(--sidebar-width);
 }
 
-body.js:not(.sidebar-visible) .sphinxsidebar {
+#sidebar-checkbox:not(:checked) ~ div.document .sphinxsidebar {
     {{ sidebar_side }}: calc(0px - var(--sidebar-width));
 }
 
@@ -857,20 +863,9 @@ div.sphinxsidebar input {
 
 #topbar-placeholder {
     z-index: 500;
-}
-
-body.js #topbar-placeholder {
     position: -webkit-sticky;
     position: sticky;
     top: 0;
-}
-
-body.sidebar-visible #topbar-placeholder {
-    margin-{{ sidebar_side }}: calc(0px - var(--sidebar-width));
-}
-
-body.js:not(.sidebar-resizing) #topbar-placeholder {
-    transition: margin-{{ sidebar_side }} {{ theme_sidebar_transition }};
 }
 
 #topbar {
@@ -890,6 +885,7 @@ body.js:not(.sidebar-resizing) #topbar-placeholder {
 }
 
 #topbar button:hover,
+#titlebar .buttons > *:hover,
 #titlebar a:hover,
 .relbar a:hover,
 .relbar a:hover .icon {
@@ -947,7 +943,6 @@ body.js #topbar {
     transition: transform {{ theme_topbar_transition }};
 }
 
-body:not(.js) #sidebar-button,
 body:not(.js) #search-button {
     display: none;
 }
@@ -1048,22 +1043,22 @@ div.body, .relbar, footer, div.articleComments {
 }
 
 {%- if theme_rightsidebar|tobool %}
-body.sidebar-visible .nav-icon {
+#sidebar-checkbox:checked ~ nav .nav-icon {
     right: var(--sidebar-width);
 }
 
 {%- if not theme_body_centered|tobool %}
-body.js:not(.sidebar-resizing) .nav-icon.previous,
+body:not(.sidebar-resizing) .nav-icon.previous,
 {%- endif %}
-body.js:not(.sidebar-resizing) .nav-icon.next {
+body:not(.sidebar-resizing) .nav-icon.next {
     transition: right {{ theme_sidebar_transition }};
 }
 {%- elif theme_body_centered|tobool %}
-body.sidebar-visible .nav-icon.previous {
+#sidebar-checkbox:checked ~ nav .nav-icon.previous {
     left: var(--sidebar-width);
 }
 
-body.js:not(.sidebar-resizing) .nav-icon.previous {
+body:not(.sidebar-resizing) .nav-icon.previous {
     transition: left {{ theme_sidebar_transition }};
 }
 {%- endif %}
@@ -1085,20 +1080,19 @@ div.viewcode-block:target {
 
 /* -- media queries --------------------------------------------------------- */
 
+{%- if theme_sidebar_overlay_width != None %}
 @media only screen and (max-width: {{ theme_sidebar_overlay_width|todim }}) {
-    body.sidebar-visible {
+    #sidebar-checkbox:checked ~ div.document,
+    #sidebar-checkbox:checked ~ .relbar,
+    #sidebar-checkbox:checked ~ footer {
         margin-{{ sidebar_side }}: 0;
     }
 
-    body.sidebar-visible #topbar-placeholder {
+    #sidebar-checkbox:checked ~ #topbar-placeholder {
         margin-{{ sidebar_side }}: 0;
     }
 
-    body.js.sidebar-visible {
-        overflow: hidden;
-    }
-
-    body.js #overlay {
+    #overlay {
         position: fixed;
         top: 0;
         left: 0;
@@ -1111,26 +1105,21 @@ div.viewcode-block:target {
         z-index: 380;
     }
 
-    body.js.sidebar-visible #overlay {
+    #sidebar-checkbox:checked ~ #overlay {
         visibility: visible;
         opacity: 1;
         transition: opacity {{ theme_sidebar_transition }};
     }
 
-    body:not(.js) .sphinxsidebar {
-        position: relative;
-        top: unset;
-        width: unset;
-    }
-
-    body.js.sidebar-visible #titlebar .parent {
+    #sidebar-checkbox:checked ~ #topbar-placeholder #titlebar .parent {
         display: unset;
     }
 
-    body.js.sidebar-visible #titlebar .top {
+    #sidebar-checkbox:checked ~ #topbar-placeholder #titlebar #titlebar .top {
         display: none;
     }
 }
+{%- endif %}
 
 body:not(.js) #fullscreen-button {
     display: none;

--- a/src/insipid_sphinx_theme/insipid/static/insipid.js
+++ b/src/insipid_sphinx_theme/insipid/static/insipid.js
@@ -92,6 +92,7 @@ $(document).ready(function () {
         } else {
             $search_form.hide();
             $search_button.attr('aria-expanded', 'false');
+            $search_button.blur();
         }
     });
 

--- a/src/insipid_sphinx_theme/insipid/theme.conf
+++ b/src/insipid_sphinx_theme/insipid/theme.conf
@@ -21,6 +21,8 @@ show_insipid = true
 
 sidebar_overlay_width = 39rem
 
+initial_sidebar_visibility_threshold = 100rem
+
 # Inherited from "basic" theme, but different default values:
 body_min_width = unset
 body_max_width = 45rem


### PR DESCRIPTION
... and several other changes.

The method is inspired by https://github.com/pradyunsg/furo (which uses it only on narrow screens). I found out about this technique in https://github.com/pydata/pydata-sphinx-theme/issues/317.

Apart from the CSS-only sidebar toggling, this contains a few mostly unrelated changes:

* initially show sidebar on very wide screens, closes #67
  * can be configured with `initial_sidebar_visibility_threshold`
* change some jQuery code to vanilla JavaScript (but still a lot of jQuery remaining)
* move the sidebar HTML code back to it's original place
  * this had been moved for the no-JS case, which has become obsolete
  * this makes the `footer` block behave as expected again when overwritten
* use `window.matchMedia()`, which I didn't know before

There is one known regression:

* scrolling on the `overlay` element is not disabled anymore (the scrolled content is visible through the semi-transparent layer)
  * this is not a biggie, but if you know a simple way to restore that, please let me know