### PR TITLE
CSS: negative left/right margins on admonitions and other boxes

### DIFF
--- a/doc/showcase/admonitions.rst
+++ b/doc/showcase/admonitions.rst
@@ -1,3 +1,7 @@
+.. tip::
+
+    Admonitions can also be used before the first headline.
+
 Admonitions
 ===========
 

--- a/doc/showcase/code-blocks.rst
+++ b/doc/showcase/code-blocks.rst
@@ -204,6 +204,13 @@ Nesting
 
         'code in quote'
 
+.. warning::
+
+    definition term
+        ::
+
+            'code in definition in admonition'
+
 .. sidebar:: Sidebar
 
     .. code-block:: python

--- a/doc/showcase/quotes.rst
+++ b/doc/showcase/quotes.rst
@@ -71,6 +71,17 @@ https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#block-quotes
 
         Block quote in an :doc:`admonition <admonitions>`.
 
+#. List item
+
+   text
+
+     block quote
+
+definition term
+   text
+
+     block quote
+
 
 Epigraphs
 ---------

--- a/src/insipid_sphinx_theme/insipid/static/insipid.css_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid.css_t
@@ -354,8 +354,9 @@ div.topic, div.sidebar, aside.sidebar {
 .section > div.admonition,
 section > div.admonition,
 div.body > div.admonition,
-/* a topic is only allowed at the top level */
-div.topic {
+.section > div.topic,
+section > div.topic,
+div.body > div.topic {
     margin: 10px -7px;
 }
 

--- a/src/insipid_sphinx_theme/insipid/static/insipid.css_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid.css_t
@@ -263,14 +263,14 @@ pre {
     font-size: 0.875em;
 }
 
-.section > div[class*=highlight],
-.section > .compound > div[class*=highlight],
-.section > .literal-block-wrapper > div[class*=highlight],
+.section > div > div.highlight,
+.section > .compound > div > div.highlight,
+.section > .literal-block-wrapper > div > div.highlight,
 .section > pre.literal-block,
 .section > .compound > pre.literal-block,
-section > div[class*=highlight],
-section > .compound > div[class*=highlight],
-section > .literal-block-wrapper > div[class*=highlight],
+section > div > div.highlight,
+section > .compound > div > div.highlight,
+section > .literal-block-wrapper > div > div.highlight,
 section > pre.literal-block,
 section > .compound > pre.literal-block {
     margin-left: -7px;

--- a/src/insipid_sphinx_theme/insipid/static/insipid.css_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid.css_t
@@ -359,7 +359,8 @@ div.topic {
     margin: 10px -7px;
 }
 
-div.sidebar {
+div.sidebar,
+aside.sidebar {
     margin-right: -7px;
 }
 

--- a/src/insipid_sphinx_theme/insipid/static/insipid.css_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid.css_t
@@ -155,8 +155,13 @@ blockquote {
     clear: left;
     margin: 10px 0;
     border: 1px solid #0002;
-    border-left-width: 6px;
-    padding: 0 20px;
+    border-left-width: 7px;
+    padding: 0 1em;
+}
+
+.section > blockquote,
+section > blockquote {
+    margin: 10px -7px;
 }
 
 blockquote.pull-quote p:not(.attribution),
@@ -258,6 +263,20 @@ pre {
     font-size: 0.875em;
 }
 
+.section > div[class*=highlight],
+.section > .compound > div[class*=highlight],
+.section > .literal-block-wrapper > div[class*=highlight],
+.section > pre.literal-block,
+.section > .compound > pre.literal-block,
+section > div[class*=highlight],
+section > .compound > div[class*=highlight],
+section > .literal-block-wrapper > div[class*=highlight],
+section > pre.literal-block,
+section > .compound > pre.literal-block {
+    margin-left: -7px;
+    margin-right: -7px;
+}
+
 code,
 code.xref,
 a code,
@@ -330,6 +349,18 @@ span.pre {
 
 div.topic, div.sidebar, aside.sidebar {
     border: none;
+}
+
+.section > div.admonition,
+section > div.admonition,
+div.body > div.admonition,
+/* a topic is only allowed at the top level */
+div.topic {
+    margin: 10px -7px;
+}
+
+div.sidebar {
+    margin-right: -7px;
 }
 
 div.admonition > p.admonition-title,
@@ -480,8 +511,15 @@ dl.field-list > dt {
 div.body dt:not(.label),
 dl.field-list > dt {
     margin-top: 1em;
-    padding: 1px 6px;
+    padding: 1px 7px;
     background-color: #f5f5f5;
+}
+
+.section > dl > dt:not(.label),
+.section > dl.field-list > dt,
+section > dl > dt:not(.label),
+section > dl.field-list > dt {
+    margin: 1em -7px 0;
 }
 
 div.body dl > dt:first-child {


### PR DESCRIPTION
This makes admonitions, code blocks and the boxes around definition terms protrude into the margins in a way that the contained text is aligned with the surrounding text.