### PR TITLE
CSS: more space between paragraphs in compact lists

### DIFF
--- a/doc/showcase/lists.rst
+++ b/doc/showcase/lists.rst
@@ -47,7 +47,11 @@ and/or a single nested list, each item containing ...
   
   - A second level paragraph.
 
-  - A second level paragraph.
+  - A second level paragraph with significantly more text in it.
+    So much text that there will be at least one line break within the paragraph.
+    This will show the difference in spacing between lines and list items.
+    Do you see a difference?
+    Or is it the same?
 
 * Another first level paragraph.
 

--- a/src/insipid_sphinx_theme/insipid/static/insipid.css_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid.css_t
@@ -481,6 +481,10 @@ ol, ul {
     padding-left: 1.2em;
 }
 
+ol.simple p, ul.simple p {
+    margin-bottom: 0.3em;
+}
+
 .toctree-wrapper ul,
 .contents ul {
     list-style: none;


### PR DESCRIPTION
See #60.

Those are still supposed to be "compact" lists, so I don't want to make the space too big.

With a space of `0.3em`I think this is still "compact" compared to `1em` in the non-compact case.