### PR TITLE
CSS: update spacing in TOC

### DIFF
--- a/doc/showcase/sections.rst
+++ b/doc/showcase/sections.rst
@@ -82,13 +82,29 @@ Some text.
     Some text.
 
 
-(Local) Table of Contents
--------------------------
+Table of Contents
+-----------------
 
 https://docutils.sourceforge.io/docs/ref/rst/directives.html#table-of-contents
 
 .. contents:: Table of Contents
+    :backlinks: none
 
+
+Local Table of Contents
+-----------------------
+
+.. contents::
+   :local:
+
+Subsection One
+^^^^^^^^^^^^^^
+
+Subsubsection
+'''''''''''''
+
+Subsection Two
+^^^^^^^^^^^^^^
 
 Nested ``toctree``
 ------------------

--- a/src/insipid_sphinx_theme/insipid/static/insipid.css_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid.css_t
@@ -502,11 +502,6 @@ ol.simple p, ul.simple p {
     padding-left: unset;
 }
 
-.toctree-wrapper li,
-.contents li {
-    line-height: normal;
-}
-
 dl.citation > dt {
     font-weight: 600;
 }

--- a/src/insipid_sphinx_theme/insipid/static/insipid.css_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid.css_t
@@ -388,7 +388,8 @@ div.topic > p.topic-title + *,
     margin-top: 0;
 }
 
-div.admonition > :first-child:not(.admonition-title) {
+div.admonition > :first-child:not(.admonition-title),
+div.topic > :first-child:not(.topic-title) {
     margin-top: 0;
 }
 
@@ -488,6 +489,12 @@ ol.simple p, ul.simple p {
 .toctree-wrapper ul,
 .contents ul {
     list-style: none;
+    margin-top: 0.5em;
+}
+
+.toctree-wrapper li:not(:first-child),
+.contents li:not(:first-child) {
+    margin-top: 0.5em;
 }
 
 .toctree-wrapper > ul,
@@ -497,7 +504,6 @@ ol.simple p, ul.simple p {
 
 .toctree-wrapper li,
 .contents li {
-    margin-top: 0.5em;
     line-height: normal;
 }
 


### PR DESCRIPTION
This affect both Sphinx and Docutils TOCs:

* https://insipid-sphinx-theme--76.org.readthedocs.build/en/76/index.html
* https://insipid-sphinx-theme--76.org.readthedocs.build/en/76/showcase/sections.html#table-of-contents