### PR TITLE
Add pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools >= 40.8.0", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This is just a minimal setup to get started.

At a later point, more things can be moved to `pyproject.toml` (see https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html).