### PR TITLE
CSS:  Larger indentation in TOC and definition lists

### DIFF
--- a/src/insipid_sphinx_theme/insipid/static/insipid.css_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid.css_t
@@ -496,6 +496,7 @@ ol.simple p, ul.simple p {
 .contents ul {
     list-style: none;
     margin-top: 0.5em;
+    padding-left: 2em;
 }
 
 .toctree-wrapper li:not(:first-child),
@@ -574,7 +575,7 @@ dd,
 dl.field-list > dd {
     padding-left: 0;
     margin-top: 3px;
-    margin-left: 20px;
+    margin-left: 2em;
 }
 
 dd:not(:last-child),


### PR DESCRIPTION
This hopefully makes it a bit easier to see the structure of definition lists as well as tables of contents.