### PR TITLE
Add role="button" to hamburger button (which actually is a <label>)

### DIFF
--- a/src/insipid_sphinx_theme/insipid/sidebar-button.html
+++ b/src/insipid_sphinx_theme/insipid/sidebar-button.html
@@ -1,6 +1,6 @@
 {# NB: "title" and some ARIA attributes are set via JavaScript. #}
 {%- if render_sidebar %}
-            <label for="sidebar-checkbox" id="sidebar-button" tabindex="0" aria-controls="sphinxsidebar" accesskey="M">
+            <label for="sidebar-checkbox" id="sidebar-button" role="button" tabindex="0" aria-controls="sphinxsidebar" accesskey="M">
               {% include 'icons/menu.svg' %}
             </label>
 {%- endif %}


### PR DESCRIPTION
I'm not sure whether that's supported by any existing tools, but at least it shows the intention.