### PR TITLE
CSS: Separate "overflow-wrap: break-word" for autosummary tables

### DIFF
--- a/src/insipid_sphinx_theme/insipid/static/insipid.css_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid.css_t
@@ -351,6 +351,10 @@ span.pre {
     overflow-wrap: anywhere;
 }
 
+table.autosummary span.pre {
+    overflow-wrap: break-word;
+}
+
 /* -- admonitions ----------------------------------------------------------- */
 
 div.topic, div.sidebar, aside.sidebar {


### PR DESCRIPTION
This is to avoid line breaks within function names in `autosummary` tables.

This is a refinement of #72.