### PR TITLE
DOC: use literal § as html_permalinks_icon

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -5,7 +5,7 @@
 
 html_theme = 'insipid'
 
-html_permalinks_icon = '\N{SECTION SIGN}'
+html_permalinks_icon = '§'
 
 # -- Recommended settings for readthedocs.org ---------------------------------
 


### PR DESCRIPTION
I think this is easier to understand.