### PR TITLE
Defer loading RTD-specific CSS file

### DIFF
--- a/src/insipid_sphinx_theme/insipid/layout.html
+++ b/src/insipid_sphinx_theme/insipid/layout.html
@@ -51,7 +51,7 @@
     <link rel="stylesheet" href="{{ pathto('_static/basic.css', 1) }}" type="text/css" />
 {{- super() }}
 {%- if READTHEDOCS|tobool and render_sidebar %}
-    <link rel="stylesheet" href="{{ pathto('_static/insipid-sidebar-readthedocs.css', 1) }}" type="text/css" />
+    <link rel="preload" href="{{ pathto('_static/insipid-sidebar-readthedocs.css', 1) }}" as="style" onload="this.onload=null;this.rel='stylesheet'">
 {%- endif %}
 {%- endblock %}
 


### PR DESCRIPTION
The RTD elements (i.e. the "badge") are loaded via JavaScript after the main page is loaded. Therefore, it doesn't seem to make sense to load the custom CSS at the very beginning of the main page load.

See https://github.com/readthedocs/readthedocs.org/issues/9134.

Are there any downsides to this?