### PR TITLE
DOC: Install requirements.txt after insipid

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,9 +6,9 @@ submodules:
 python:
   version: 3
   install:
-    - requirements: doc/requirements.txt
     - method: pip
       path: .
+    - requirements: doc/requirements.txt
   system_packages: true
 formats:
   - htmlzip


### PR DESCRIPTION
This way, `requirements.txt` can downgrade packages if desired.