### PR TITLE
CSS: use "clear" on "literal-block-wrapper"

### DIFF
--- a/src/insipid_sphinx_theme/insipid/static/insipid.css_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid.css_t
@@ -320,6 +320,10 @@ div.code-block-caption {
     font-size: unset;
 }
 
+div.literal-block-wrapper {
+    clear: both;
+}
+
 td.linenos .linenodiv pre {
     color: #666;
     background-color: transparent;


### PR DESCRIPTION
This is a problematic case: https://sphinx-themes.org/sample-sites/insipid-sphinx-theme/kitchen-sink/generic/#code-with-sidebar