### PR TITLE
CSS: Make .compound rules less specific

### DIFF
--- a/src/insipid_sphinx_theme/insipid/static/insipid.css_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid.css_t
@@ -210,22 +210,22 @@ section > hr.docutils {
     margin-right: -7px;
 }
 
-div.compound:not(.toctree-wrapper) {
+.compound:not(.toctree-wrapper) {
     margin-top: 1em;
     margin-bottom: 1em;
 }
 
-div.compound:not(.toctree-wrapper) > * {
+.compound:not(.toctree-wrapper) > * {
     margin-top: 0.2em;
     margin-bottom: 0.2em;
 }
 
-div.compound:not(.toctree-wrapper) > *:first-child {
+.compound:not(.toctree-wrapper) > *:first-child {
     margin-top: 0;
     margin-bottom: 0.2em;
 }
 
-div.compound:not(.toctree-wrapper) > *:last-child {
+.compound:not(.toctree-wrapper) > *:last-child {
     margin-top: 0.2em;
     margin-bottom: 0;
 }


### PR DESCRIPTION
... to allow being overwritten by other rules.