### PR TITLE
Make tables scrollable with "display: block"

### DIFF
--- a/src/insipid_sphinx_theme/insipid/static/insipid.css_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid.css_t
@@ -179,10 +179,6 @@ blockquote p.attribution {
     text-align: end;
 }
 
-div.insipid-horizontally-scrollable {
-    overflow-x: auto;
-}
-
 div.body a:target,
 strong:target {
     padding: 3px;
@@ -487,8 +483,12 @@ div.body .sidebar dl:not(.glossary) > dt {
 /* -- tables and lists ------------------------------------------------------ */
 
 table.docutils {
+    overflow-x: auto;
+    display: block;
     border-collapse: separate;
     border-spacing: 4px 4px;
+    margin-top: 1em;
+    margin-bottom: 1em;
 }
 
 table.docutils th {

--- a/src/insipid_sphinx_theme/insipid/static/insipid.js
+++ b/src/insipid_sphinx_theme/insipid/static/insipid.js
@@ -4,7 +4,7 @@
     } else {
         dom_loaded();
     }
-})(() => { 
+})(() => {
     'use strict';
 
     // make sure all scripts are re-executed when navigating to cached page
@@ -12,16 +12,6 @@
 
     const topbar = document.getElementById('topbar');
     const topbar_placeholder = document.getElementById('topbar-placeholder');
-
-    // make large tables horizontally scrollable
-    document.querySelectorAll(
-        'table.docutils:not(.field-list,.footnote,.citation)'
-    ).forEach(el => {
-        const wrapper = document.createElement('div');
-        wrapper.classList.add('insipid-horizontally-scrollable');
-        el.parentNode.insertBefore(wrapper, el);
-        wrapper.appendChild(el);
-    });
 
     const threshold = 10;
 


### PR DESCRIPTION
This avoids injecting a `<div>` element via JavaScript, which means that it also works for visitors who have disabled JavaScript in their browser.

As a side effect, tables are now left-aligned instead of centered.