### PR TITLE
Require Sphinx 5.0

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -14,6 +14,18 @@ Installation and Usage
     If you have installed the module already,
     you can use the ``--upgrade`` flag to get the newest release.
 
+    .. note::
+
+        By default, a recent Sphinx version is required and automatically
+        installed when installing ``insipid-sphinx-theme``.
+        Older Sphinx versions are supported to some degree
+        (some features might not be rendered as in newer versions, see
+        https://insipid-sphinx-theme.readthedocs.io/en/sphinx3/ and
+        https://insipid-sphinx-theme.readthedocs.io/en/sphinx4/),
+        but those older versions have to be installed manually
+        and ``insipid-sphinx-theme`` has to be installed
+        with the ``--no-deps`` flag.
+
 #.  Edit the :file:`conf.py` file
     (just create an empty file if it doesn't exist yet,
     or use :doc:`sphinx:man/sphinx-quickstart`) and add/edit the line:

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ setup(
     ]},
     python_requires='>=3.6',
     install_requires=[
-        'sphinx>=3.1.2',
+        'sphinx>=5',
+        'docutils>=0.18',
         'jinja2>=2.11',  # suport for pathlib.Path
     ],
     author='Matthias Geier',


### PR DESCRIPTION
This is to make sure that Sphinx and docutils are upgraded on systems where old versions are installed.

The theme itself still works (reasonably) with Sphinx 3 and 4.

However, to install it on old systems, the flag `--no-deps` has to be used.