### PR TITLE
Monkey-patch focusSearchBar() to support "/" key binding

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -34,6 +34,7 @@ html_theme_options = {
     #'body_centered': False,
     #'body_max_width': None,
     #'breadcrumbs': True,
+    #'enable_search_shortcuts': False,
     #'globaltoc_collapse': False,
     #'globaltoc_includehidden': True,
     #'initial_sidebar_visibility_threshold': None,

--- a/src/insipid_sphinx_theme/insipid/static/insipid.js
+++ b/src/insipid_sphinx_theme/insipid/static/insipid.js
@@ -69,26 +69,42 @@
         event.preventDefault();
     });
 
-    // show search
-    const search_form = document.getElementById('search-form');
     const search_button = document.getElementById('search-button');
-    search_button.addEventListener('click', event => {
-        try {
-            // https://readthedocs-sphinx-search.readthedocs.io/
-            showSearchModal();
-            return;
-        } catch(e) {}
-        if (window.getComputedStyle(search_form).display === 'none') {
+    if (search_button) {
+        const search_form = document.getElementById('search-form');
+
+        function show_search() {
+            try {
+                // https://readthedocs-sphinx-search.readthedocs.io/
+                showSearchModal();
+                return;
+            } catch(e) {}
             search_form.style.display = 'flex';
             search_button.setAttribute('aria-expanded', 'true');
             search_form.querySelector('input').focus();
             document.body.classList.remove('topbar-folded');
-        } else {
+        }
+
+        function hide_search() {
             search_form.style.display = 'none';
             search_button.setAttribute('aria-expanded', 'false');
             search_button.blur();
         }
-    });
+
+        function toggle_search() {
+            if (window.getComputedStyle(search_form).display === 'none') {
+                show_search();
+            } else {
+                hide_search();
+            }
+        }
+
+        search_button.addEventListener('click', toggle_search);
+        if (Documentation.focusSearchBar) {
+            // Monkey-patch function provided by Sphinx:
+            Documentation.focusSearchBar = show_search;
+        }
+    }
 
     const fullscreen_button = document.getElementById('fullscreen-button');
     if (document.fullscreenEnabled) {


### PR DESCRIPTION
Support for the `/` key was added in https://github.com/sphinx-doc/sphinx/pull/9337 and it can be disabled by setting the theme option `enable_search_shortcuts` to `False`.