### PR TITLE
CSS: remove "italic" from "in-view", reduce "letter-spacing" instead

### DIFF
--- a/src/insipid_sphinx_theme/insipid/static/insipid.css_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid.css_t
@@ -861,8 +861,8 @@ div.sphinxsidebar a {
 }
 
 div.sphinxsidebar a.in-view {
-    font-style: italic;
     font-weight: 600;
+    letter-spacing: -0.013em;
 }
 
 div.sphinxsidebar code {


### PR DESCRIPTION
I originally didn't want to use `italic`, because I don't really like the look of it, but switching to bold alone made the text significantly wider, which led to line breaks in some cases which led to unwanted movement in the sidebar when scrolling the main text.

I just learned about the hack of using a negative `letter-spacing`, which looks promising.

The problem is that this depends on the used font, which might be different on different browsers.
~I still have to check this on multiple browsers.~