### PR TITLE
IntersectionObserver: support for domain object headers

### DIFF
--- a/src/insipid_sphinx_theme/insipid/static/insipid-sidebar.js_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid-sidebar.js_t
@@ -324,6 +324,17 @@
         if (id) {
             id = id.slice(1);
             section = document.getElementById(decodeURI(id));
+            // Detect API doc headers:
+            let single_definition_term = (
+                section.nodeName == 'DT' &&
+                section.nextElementSibling.nodeName == 'DD' &&
+                !section.nextElementSibling.nextElementSibling &&
+                section.parentElement.nodeName == 'DL');
+            if (single_definition_term) {
+                // The <dl> contains only a single <dt> + <dd>,
+                // therefore we can observe the whole <dl>.
+                section = section.parentElement;
+            }
         } else {
             // NB: The first section has no hash, so we don't know its ID:
             section = document.querySelector('div.body .section, div.body section');


### PR DESCRIPTION
This improves the handling of API doc headers once https://github.com/sphinx-doc/sphinx/pull/10807 is merged.

For older Sphinx versions, this should have no effect.