### PR TITLE
DOC: better escaping for utteranc.es issue-term

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -4,7 +4,20 @@
 {% if sourcename is defined %}
 <script src="https://utteranc.es/client.js"
         repo="mgeier/insipid-sphinx-theme"
-        issue-term="comments:{{ pagename|urlencode }}"
+{#-
+Github's issue search is somewhat fuzzy, but we would like an exact match for issue-term.
+Spaces, commas, hyphens, slashes etc. would be treated as search term separators,
+which might lead to the wrong comments being included.  Therefore, we are replacing
+some characters with underscores, and "urlencode" will take care of the rest.
+#}
+        issue-term="comments:{{ pagename
+            |replace(' ', '_')
+            |replace(',', '_')
+            |replace('-', '_')
+            |replace('~', '_')
+            |replace('/', '_')
+            |urlencode
+        }}"
         label="comments"
         theme="preferred-color-scheme"
         crossorigin="anonymous"


### PR DESCRIPTION
This is maybe not strictly necessary in our docs, but if a page name is contained in the beginning of another page name (e.g. `table` and `table-tennis`), the comments of the shorter name will incorrectly point to the comments of the longer one.