### PR TITLE
Use readthedocs-embed-flyout, scroll with sidebar

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -62,7 +62,11 @@ html_sidebars = {
        'separator.html',
        'indices.html',
    ],
-   'showcase/no-sidebar': [],  # To demonstrate a page without a sidebar
+   'showcase/different-sidebar': [
+       'localtoc.html',
+       'searchbox.html',
+   ],
+   'showcase/no-sidebar': [],
 }
 
 html_static_path = ['_static']

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -33,6 +33,7 @@
     showcase/math
     showcase/api-doc
     showcase/sections
+    showcase/different-sidebar
     showcase/no-sidebar
 
 ----

--- a/doc/showcase/different-sidebar.rst
+++ b/doc/showcase/different-sidebar.rst
@@ -1,0 +1,31 @@
+Page With Different Sidebar
+===========================
+
+This page has different content in the sidebar,
+see :confval:`html_sidebars` in :download:`conf.py <../conf.py>`:
+
+.. literalinclude:: ../conf.py
+    :caption: conf.py
+    :language: python
+    :linenos:
+    :lineno-match:
+    :start-at: html_sidebars
+    :end-at: }
+
+
+Local Table of Contents
+-----------------------
+
+Instead of displaying the whole TOC in the sidebar
+with ``globaltoc.html``,
+a local TOC can be shown with ``localtoc.html``.
+
+
+Search Box
+----------
+
+If you don't like the search button in the topbar,
+you can also put a search field into the sidebar
+by selecting the template ``searchbox.html``.
+
+Like the search button, this is only available when JavaScript is enabled.

--- a/src/insipid_sphinx_theme/insipid/layout.html
+++ b/src/insipid_sphinx_theme/insipid/layout.html
@@ -41,9 +41,13 @@
 {% endif %}
 
 
-{% if sidebars and 'ethical-ad.html' not in sidebars %}
+{% if (sidebars != []) and 'ethical-ad.html' not in sidebars %}
 {# Dummy assignment to be able to call append() #}
 {% set _dummy = sidebars.append('ethical-ad.html') %}
+{% endif %}
+{% if READTHEDOCS|tobool and (sidebars != []) and 'readthedocs-embed-flyout.html' not in sidebars %}
+{# Dummy assignment to be able to call append() #}
+{% set _dummy = sidebars.append('readthedocs-embed-flyout.html') %}
 {% endif %}
 
 

--- a/src/insipid_sphinx_theme/insipid/readthedocs-embed-flyout.html
+++ b/src/insipid_sphinx_theme/insipid/readthedocs-embed-flyout.html
@@ -1,0 +1,12 @@
+{# We duplicate "rst-current-version" to be able to make it sticky. #}
+{# It is initially invisible and will be enabled via JavaScript below. #}
+<div id="duplicated-readthedocs-versions" class="rst-versions" role="note" style="display: none;">
+  <span class="rst-current-version">
+    <span class="fa fa-book"> Read the Docs</span>
+    {{ current_version }}
+  </span>
+</div>
+{# Only show when JavaScript is enabled: #}
+<script>document.currentScript.previousElementSibling.style.display = 'block';</script>
+{# This is where https://readthedocs.org/ injects the version/language switcher #}
+<div id="readthedocs-embed-flyout"></div>

--- a/src/insipid_sphinx_theme/insipid/static/insipid-sidebar-readthedocs.css_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid-sidebar-readthedocs.css_t
@@ -1,34 +1,47 @@
 {%- set sidebar_side = 'right' if theme_rightsidebar|tobool else 'left' %}
 
-:root {
-    --readthedocs-badge-height: 0px;
+#ethical-ad-placement {
+    margin-top: auto;
+    padding-top: 3em;
 }
 
-div.sphinxsidebar {
-    bottom: var(--readthedocs-badge-height);
+#readthedocs-embed-flyout, #duplicated-readthedocs-versions {
+    margin-left: -10px;
+    margin-right: -10px;
 }
 
-.injected .rst-versions.rst-badge {
-    {{ sidebar_side }}: 0;
-    bottom: 0;
-    width: var(--sidebar-width);
-    max-width: unset;
+#readthedocs-embed-flyout {
+    margin-bottom: -10px;
 }
 
-#sidebar-checkbox:not(:checked) ~ .injected .rst-versions.rst-badge {
-    {{ sidebar_side }}: calc(0px - var(--sidebar-width));
+#duplicated-readthedocs-versions {
+    position: sticky;
+    width: auto;
 }
 
-.injected .rst-versions.shift-up {
-    max-height: calc(100vh - var(--topbar-height));
+#readthedocs-embed-flyout .rst-versions.rst-badge {
+    position: static;
+    max-width: none;
 }
 
-.injected .rst-versions.rst-badge .rst-current-version {
-    text-align: right;
+{# See https://github.com/readthedocs/readthedocs.org/pull/7375
+   and https://github.com/readthedocs/sphinx_rtd_theme/pull/1297 #}
+#readthedocs-embed-flyout .rst-versions.shift-up {
+    max-height: none;
 }
 
-.injected .rst-versions.rst-badge .rst-current-version .fa-book {
-    float: left;
+/* We have duplicated this section, so we don't need the second instance: */
+#readthedocs-embed-flyout .rst-versions.rst-badge .rst-current-version {
+    display: none;
+}
+
+#duplicated-readthedocs-versions .rst-current-version {
+    font-size: 0.9rem;
+}
+
+#readthedocs-embed-flyout .rst-versions .rst-other-versions {
+    display: block;
+    font-size: 0.9rem;
 }
 
 #flyout-search-form input {
@@ -52,7 +65,6 @@ div.sphinxsidebar {
     width: unset;
 }
 
-body:not(.sidebar-resizing) .rst-versions.rst-badge,
 body:not(.sidebar-resizing) .ethical-fixedfooter {
     transition: {{ sidebar_side }} {{ theme_sidebar_transition }};
 }

--- a/src/insipid_sphinx_theme/insipid/static/insipid-sidebar.js_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid-sidebar.js_t
@@ -242,34 +242,6 @@
         resizeObserver.observe(topbar);
     }
 
-{%- if READTHEDOCS|tobool %}
-    function setResizeObserver() {
-        const badge = document.querySelector('.rst-versions.rst-badge');
-        if (badge === null) {
-            console.log('waiting for readthedocs.org badge');
-            window.requestAnimationFrame(setResizeObserver);
-        } else {
-            if (window.ResizeObserver) {
-                const resizeObserver = new ResizeObserver(entries => {
-                    for (let entry of entries) {
-                        let height;
-                        if (entry.borderBoxSize && entry.borderBoxSize.length > 0) {
-                            height = entry.borderBoxSize[0].blockSize;
-                        } else {
-                            height = entry.contentRect.height;
-                        }
-                        root.css('--readthedocs-badge-height', height + 'px');
-                    }
-                });
-                resizeObserver.observe(badge);
-            } else {
-                root.css('--readthedocs-badge-height', badge.offsetHeight + 'px');
-            }
-        }
-    };
-    window.requestAnimationFrame(setResizeObserver);
-{%- endif %}
-
     let current = [];
     let links = [];
 
@@ -290,10 +262,16 @@
     }
 {%- endif %}
 
+{%- if READTHEDOCS|tobool %}
+    const bottom_space = 42;
+{%- else %}
+    const bottom_space = 0;
+{%- endif %}
+
     if (current.length) {
         const top = current[0].getBoundingClientRect().top;
         const bottom = current[current.length - 1].getBoundingClientRect().bottom;
-        if (top < topbar.offsetHeight || bottom > sidebar.offsetHeight) {
+        if (top < topbar.offsetHeight || bottom > (sidebar.offsetHeight - bottom_space)) {
             current[0].scrollIntoView(true);
         }
     }
@@ -347,9 +325,17 @@
             if (small_screen.matches) {
                 hide();
             }
-        })
+        });
 {%- endif %}
     });
+
+{%- if READTHEDOCS|tobool %}
+    const rtd_current_version = document.getElementById('duplicated-readthedocs-versions');
+    const rtd_other_versions = document.getElementById('readthedocs-embed-flyout');
+    rtd_current_version.addEventListener('click', event => {
+        rtd_other_versions.scrollIntoView(true);
+    });
+{%- endif %}
 });
 
 {#

--- a/src/insipid_sphinx_theme/insipid/static/insipid.css_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid.css_t
@@ -74,7 +74,8 @@ div.sphinxsidebar {
 }
 
 {%- if READTHEDOCS|tobool %}
-.injected .rst-versions.shift-up {
+/* These settings are only relevant for pages without a sidebar: */
+body > .injected .rst-versions.shift-up {
     max-height: calc(100vh - var(--topbar-height) - 50px);
     overflow-y: auto;
     overscroll-behavior: contain;
@@ -82,17 +83,17 @@ div.sphinxsidebar {
     scrollbar-color: #ccc transparent;
 }
 
-.rst-versions.shift-up .rst-current-version {
+body > .injected .rst-versions.shift-up .rst-current-version {
     position: sticky;
     top: 0;
 }
 
-.injected .rst-versions.shift-up::-webkit-scrollbar {
+body > .injected .rst-versions.shift-up::-webkit-scrollbar {
     width: 7px;
     background: transparent;
 }
 
-.injected .rst-versions.shift-up::-webkit-scrollbar-thumb {
+body > .injected .rst-versions.shift-up::-webkit-scrollbar-thumb {
     background: #ccc;
 }
 {%- endif %}
@@ -729,6 +730,7 @@ div.sphinxsidebar {
     overflow-y: auto;
     float: unset;
     margin-left: unset;  /* override basic.css */
+    padding-top: var(--topbar-height);
     z-index: 390;
     color: #333;
     background-color: #f5f5f5;
@@ -755,8 +757,11 @@ body:not(.sidebar-resizing) .sphinxsidebar {
 
 div.sphinxsidebarwrapper {
     position: relative;  /* reference for sidebar-resize-handle */
-    margin-top: var(--topbar-height);
+    box-sizing: border-box;
     padding: 10px;
+    display: flex;
+    flex-direction: column;
+    min-height: 100%;
 }
 
 div.sphinxsidebarwrapper > :first-child {


### PR DESCRIPTION
This is only relevant when the docs are hosted on readthedocs.org.

With this, the RTD version switcher is included as part of the sidebar, which means it can be scrolled into view, or it might even be initially visible if there is a short TOC.

The line with the current version is still visible all the time (it's "sticky") and clicking on it brings the RTD version selector into view, similar to how it was before.

Unlike before, the version selector doesn't have to be clicked away, it can simply be scrolled away.