### PR TITLE
CSS: make separation line visible again by setting 100% width

### DIFF
--- a/src/insipid_sphinx_theme/insipid/static/insipid.css_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid.css_t
@@ -199,6 +199,7 @@ strong:target {
 hr.docutils {
     border: 0;
     border-top: solid 1px #ccc;
+    width: 100%;
 }
 
 .section > hr.docutils,


### PR DESCRIPTION
The line disappeared when I switched to `flex` layout in #125.