### PR TITLE
Make sidebar separator visible again

### DIFF
--- a/src/insipid_sphinx_theme/insipid/separator.html
+++ b/src/insipid_sphinx_theme/insipid/separator.html
@@ -1,2 +1,2 @@
 {# To be used in html_sidebars #}
-<hr class="docutils" />
+<div><hr class="docutils"></div>


### PR DESCRIPTION
This is an alternative to #129.