### PR TITLE
Remove indices from sidebar by default

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -59,8 +59,6 @@ html_sidebars = {
        'github-badge.html',  # Custom template, see _templates/
        'home.html',
        'globaltoc.html',
-       'separator.html',
-       'indices.html',
    ],
    'showcase/different-sidebar': [
        'localtoc.html',

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -38,6 +38,8 @@
 
 ----
 
-:ref:`genindex`
+.. toctree::
+    :caption: Indices
 
-:ref:`py-modindex`
+    genindex
+    modindex

--- a/src/insipid_sphinx_theme/insipid/theme.conf
+++ b/src/insipid_sphinx_theme/insipid/theme.conf
@@ -1,7 +1,7 @@
 [theme]
 inherit = basic
 stylesheet = insipid.css
-sidebars = globaltoc.html, separator.html, indices.html
+sidebars = globaltoc.html
 pygments_style = friendly
 
 [options]


### PR DESCRIPTION
This is a breaking change, so it should be merged for version 0.5.0.