### PR TITLE
RTD: Clickable version selector is always at the bottom

### DIFF
--- a/src/insipid_sphinx_theme/insipid/readthedocs-embed-flyout.html
+++ b/src/insipid_sphinx_theme/insipid/readthedocs-embed-flyout.html
@@ -1,3 +1,5 @@
+{# This is where https://readthedocs.org/ injects the version/language switcher #}
+<div id="readthedocs-embed-flyout"></div>
 {# We duplicate "rst-current-version" to be able to make it sticky. #}
 {# It is initially invisible and will be enabled via JavaScript below. #}
 <div id="duplicated-readthedocs-versions" class="rst-versions" role="note" style="display: none;">
@@ -8,5 +10,3 @@
 </div>
 {# Only show when JavaScript is enabled: #}
 <script>document.currentScript.previousElementSibling.style.display = 'block';</script>
-{# This is where https://readthedocs.org/ injects the version/language switcher #}
-<div id="readthedocs-embed-flyout"></div>

--- a/src/insipid_sphinx_theme/insipid/static/insipid-sidebar-readthedocs.css_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid-sidebar-readthedocs.css_t
@@ -11,7 +11,7 @@
     margin-right: -10px;
 }
 
-#readthedocs-embed-flyout {
+#duplicated-readthedocs-versions {
     margin-bottom: -10px;
 }
 

--- a/src/insipid_sphinx_theme/insipid/static/insipid-sidebar.js_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid-sidebar.js_t
@@ -332,8 +332,13 @@
 {%- if READTHEDOCS|tobool %}
     const rtd_current_version = document.getElementById('duplicated-readthedocs-versions');
     const rtd_other_versions = document.getElementById('readthedocs-embed-flyout');
+    const sidebarwrapper = document.querySelector('.sphinxsidebarwrapper');
     rtd_current_version.addEventListener('click', event => {
-        rtd_other_versions.scrollIntoView(true);
+        if (sidebar.scrollTop >= sidebar.scrollHeight - sidebar.clientHeight) {
+            sidebarwrapper.scrollIntoView(true);
+        } else {
+            rtd_other_versions.scrollIntoView(true);
+        }
     });
 {%- endif %}
 });

--- a/src/insipid_sphinx_theme/insipid/static/insipid-sidebar.js_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid-sidebar.js_t
@@ -334,7 +334,7 @@
     const rtd_other_versions = document.getElementById('readthedocs-embed-flyout');
     const sidebarwrapper = document.querySelector('.sphinxsidebarwrapper');
     rtd_current_version.addEventListener('click', event => {
-        if (rtd_other_versions.offsetTop - 1 <= sidebar.scrollTop || sidebar.scrollTop >= sidebar.scrollHeight - sidebar.offsetHeight) {
+        if (rtd_other_versions.offsetTop - 1 < sidebar.scrollTop || sidebar.scrollTop + 1 > sidebar.scrollHeight - sidebar.offsetHeight) {
             sidebarwrapper.scrollIntoView(true);
         } else {
             rtd_other_versions.scrollIntoView(true);

--- a/src/insipid_sphinx_theme/insipid/static/insipid-sidebar.js_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid-sidebar.js_t
@@ -334,7 +334,7 @@
     const rtd_other_versions = document.getElementById('readthedocs-embed-flyout');
     const sidebarwrapper = document.querySelector('.sphinxsidebarwrapper');
     rtd_current_version.addEventListener('click', event => {
-        if (sidebar.scrollTop >= sidebar.scrollHeight - sidebar.clientHeight) {
+        if (rtd_other_versions.offsetTop - 1 <= sidebar.scrollTop || sidebar.scrollTop >= sidebar.scrollHeight - sidebar.offsetHeight) {
             sidebarwrapper.scrollIntoView(true);
         } else {
             rtd_other_versions.scrollIntoView(true);

--- a/src/insipid_sphinx_theme/insipid/static/insipid-sidebar.js_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid-sidebar.js_t
@@ -334,7 +334,7 @@
     const rtd_other_versions = document.getElementById('readthedocs-embed-flyout');
     const sidebarwrapper = document.querySelector('.sphinxsidebarwrapper');
     rtd_current_version.addEventListener('click', event => {
-        if (rtd_other_versions.offsetTop - 1 < sidebar.scrollTop || sidebar.scrollTop + 1 > sidebar.scrollHeight - sidebar.offsetHeight) {
+        if (sidebar.scrollTop + 1 > rtd_other_versions.offsetTop || sidebar.scrollTop + 1 > sidebar.scrollHeight - sidebar.offsetHeight) {
             sidebar.scroll({top: 0, behavior:'smooth'});
         } else {
             sidebar.scroll({top: rtd_other_versions.offsetTop, behavior:'smooth'});

--- a/src/insipid_sphinx_theme/insipid/static/insipid-sidebar.js_t
+++ b/src/insipid_sphinx_theme/insipid/static/insipid-sidebar.js_t
@@ -335,9 +335,9 @@
     const sidebarwrapper = document.querySelector('.sphinxsidebarwrapper');
     rtd_current_version.addEventListener('click', event => {
         if (rtd_other_versions.offsetTop - 1 < sidebar.scrollTop || sidebar.scrollTop + 1 > sidebar.scrollHeight - sidebar.offsetHeight) {
-            sidebarwrapper.scrollIntoView(true);
+            sidebar.scroll({top: 0, behavior:'smooth'});
         } else {
-            rtd_other_versions.scrollIntoView(true);
+            sidebar.scroll({top: rtd_other_versions.offsetTop, behavior:'smooth'});
         }
     });
 {%- endif %}


### PR DESCRIPTION
This way, you can click to "open" and "close" the version flyout without having to move your mouse pointer.

I generally prefer when clickable things don't move when I click on them.