### PR TITLE
DOC: Don't limit TOC depth but hide main TOC by default

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -2,11 +2,15 @@
 
 ----
 
+.. raw:: html
+
+    <details>
+    <summary>click here to see full table of contents</summary>
+
 .. NB: "--" is not replaced in :caption:!
 
 .. toctree::
     :caption: Part One – Documentation
-    :maxdepth: 2
 
     intro
     usage
@@ -22,7 +26,6 @@
 .. toctree::
     :caption: Part Two – Showcase
     :numbered:
-    :maxdepth: 1
 
     showcase/index
     showcase/basic-formatting
@@ -43,3 +46,7 @@
 :ref:`genindex`
 
 :ref:`py-modindex`
+
+.. raw:: html
+
+    </details>


### PR DESCRIPTION
At first I thought about hiding the TOC and making a separate `contents.html` page, like at https://www.sphinx-doc.org/en/master/contents.html, but then I thought about `<details>` and I think this is better.