### PR TITLE
CI/RTD: use unspecific Python version "3"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3"
     - name: Double-check Python version
       run: |
         python --version

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,7 +2,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3"
 submodules:
   include: all
 python:


### PR DESCRIPTION
CI fails because of https://github.com/sphinx-doc/sphinx/issues/10440.