### PR TITLE
Remove license classifier

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,5 +13,7 @@ python:
     - method: pip
       path: .
     - requirements: doc/requirements.txt
+sphinx:
+  configuration: doc/conf.py
 formats:
   - htmlzip

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2020-2023, Matthias Geier
+Copyright (c) 2020-2025, Matthias Geier
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "insipid-sphinx-theme"
+license = "BSD-2-Clause"
 dynamic = ["version"]
 description = "An insipid Sphinx theme"
 readme = "README.rst"
@@ -20,7 +21,6 @@ requires-python = ">= 3.6"
 classifiers = [
   "Framework :: Sphinx",
   "Framework :: Sphinx :: Theme",
-  "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",


### PR DESCRIPTION
This caused a warning:

```
      setuptools.warnings.SetuptoolsDeprecationWarning: License classifiers are deprecated.
      !!
      
              ********************************************************************************
              Please consider removing the following classifiers in favor of a SPDX license expression:
      
              License :: OSI Approved :: BSD License
      
              See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
              ********************************************************************************
      
      !!
```