### PR TITLE
Fix icons missing from release builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
+      with:
+        submodules: true
     - name: Install uv
       uses: astral-sh/setup-uv@v7
     - name: Build a binary wheel and a source tarball


### PR DESCRIPTION
Submodules were not included in v0.4.3 release artifacts uploaded to PyPI, making them broken.