### PR TITLE
Remove CSS classes from Sphinx attribution to restore i18n

### DIFF
--- a/src/insipid_sphinx_theme/insipid/sphinx.html
+++ b/src/insipid_sphinx_theme/insipid/sphinx.html
@@ -1,6 +1,6 @@
 {# To be used in footer.html #}
 {%- if show_sphinx %}
-      {% trans sphinx_version=sphinx_version|e %}Created using <a class="reference external" href="https://www.sphinx-doc.org/">Sphinx</a> {{ sphinx_version }}.{% endtrans %}
+      {% trans sphinx_version=sphinx_version|e %}Created using <a href="https://www.sphinx-doc.org/">Sphinx</a> {{ sphinx_version }}.{% endtrans %}
 {%- endif %}
 {%- if theme_show_insipid|tobool %}
       <a class="reference external" href="https://insipid-sphinx-theme.readthedocs.io/">Insipid Theme</a>.


### PR DESCRIPTION
Playing around with https://github.com/mgeier/sphinx-last-updated-by-git/pull/97, I found out that "Created using Sphinx" wasn't localized to any non-English languages.

I guess we have to give up on CSS formatting as external link in order to get localization.